### PR TITLE
feat: Fix bug in ActivateTableActionsUseCase

### DIFF
--- a/backend/src/entities/table-actions/use-cases/activate-table-actions.use.case.ts
+++ b/backend/src/entities/table-actions/use-cases/activate-table-actions.use.case.ts
@@ -98,7 +98,7 @@ export class ActivateTableActionsUseCase
       }
       if (operationStatusCode >= 300 && operationStatusCode < 400) {
         operationResult = OperationResultStatusEnum.successfully;
-        return { location: result.data } as unknown as ActivatedTableActionsDS;
+        return { location: result.headers?.location } as unknown as ActivatedTableActionsDS;
       }
       if (operationStatusCode >= 400 && operationStatusCode <= 599) {
         operationResult = OperationResultStatusEnum.unsuccessfully;


### PR DESCRIPTION
The bug was causing the returned location to be undefined when the operation status code was between 300 and 400. This commit fixes the bug by accessing the `location` property from the `result.headers` object instead of `result.data`.