### PR TITLE
Refactor LRUStorage and DataAccessObject creation

### DIFF
--- a/shared-code/src/caching/lru-storage.ts
+++ b/shared-code/src/caching/lru-storage.ts
@@ -19,7 +19,6 @@ const tableForeignKeysCache = new LRUCache(CACHING_CONSTANTS.DEFAULT_TABLE_STRUC
 const tablePrimaryKeysCache = new LRUCache(CACHING_CONSTANTS.DEFAULT_TABLE_STRUCTURE_ELEMENTS_CACHE_OPTIONS);
 
 export class LRUStorage {
-
   public static setMongoDbCache(connection: ConnectionParams, newDb: MongoClientDB): void {
     mongoDbCache.set(this.getConnectionIdentifier(connection), newDb);
   }
@@ -140,6 +139,9 @@ export class LRUStorage {
         signing_key: connectionParams.signing_key,
       };
       return JSON.stringify(cacheObj);
+    }
+    if (connectionParams.isTestConnection) {
+      return connectionParams.host;
     }
     if (connectionParams.ssh) {
       const cacheObj = {

--- a/shared-code/src/data-access-layer/shared/create-data-access-object.ts
+++ b/shared-code/src/data-access-layer/shared/create-data-access-object.ts
@@ -49,7 +49,7 @@ export function getDataAccessObject(
       return new DataAccessObjectIbmDb2(connectionParamsToIbmDB2);
     case ConnectionTypesEnum.mongodb:
       const connectionParamsMongo = buildConnectionParams(connectionParams);
-      return new DataAccessObjectMongo(connectionParamsMongo);  
+      return new DataAccessObjectMongo(connectionParamsMongo);
     default:
       if (!agentTypes.includes(connectionParams.type)) {
         throw new Error(ERROR_MESSAGES.CONNECTION_TYPE_INVALID);
@@ -69,6 +69,7 @@ function buildAgentConnectionParams(connectionParams: IUnknownConnectionParams):
     signing_key: connectionParams.signing_key,
     token: connectionParams.agent.token,
     type: connectionParams.type,
+    isTestConnection: false,
   };
 }
 
@@ -78,7 +79,7 @@ function buildConnectionParams(connectionParams: IUnknownConnectionParams): Conn
   if (connectionParams.ssh) {
     requiredKeys.push('sshHost', 'sshPort', 'sshUsername');
   }
-  
+
   const missingKeys = requiredKeys.filter((key) => !connectionParams[key]);
   if (missingKeys.length > 0) {
     throw new Error(`Missing required key${missingKeys.length > 1 ? 's' : ''}: ${missingKeys.join(', ')}`);
@@ -104,5 +105,6 @@ function buildConnectionParams(connectionParams: IUnknownConnectionParams): Conn
     azure_encryption: connectionParams.azure_encryption || false,
     signing_key: connectionParams.signing_key || null,
     authSource: connectionParams.authSource || null,
+    isTestConnection: connectionParams.isTestConnection || false,
   };
 }

--- a/shared-code/src/data-access-layer/shared/data-structures/connections-params.ds.ts
+++ b/shared-code/src/data-access-layer/shared/data-structures/connections-params.ds.ts
@@ -38,6 +38,8 @@ export class ConnectionParams {
   signing_key: string;
 
   authSource: string | null;
+
+  isTestConnection: boolean;
 }
 
 export class ConnectionAgentParams {
@@ -46,4 +48,5 @@ export class ConnectionAgentParams {
   signing_key: string;
   token: string;
   type: string;
+  isTestConnection: boolean;
 }


### PR DESCRIPTION
- Add support for test connections in LRUStorage
- Refactor buildConnectionParams function in create-data-access-object.ts (test connections is cached only by hostname)
- Add isTestConnection property to ConnectionParams and ConnectionAgentParams