### PR TITLE
Fix API routes in tests to include 'saas/' prefix and drop 'transacti…

### DIFF
--- a/backend/test/ava-tests/saas-tests/action-rules-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/action-rules-e2e.test.ts
@@ -76,6 +76,7 @@ async function resetPostgresTestDB() {
       port: port,
     },
   });
+  await Knex.schema.dropTableIfExists('transactions');
   await Knex.schema.dropTableIfExists(testTableName);
   await Knex.schema.createTableIfNotExists(testTableName, function (table) {
     table.increments();

--- a/backend/test/ava-tests/saas-tests/company-info-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/company-info-e2e.test.ts
@@ -806,7 +806,7 @@ test.serial(
     });
 
     const subscriptionUpgradeResult = await fetch(
-      `http://rocketadmin-private-microservice:3001/company/subscription/upgrade/${foundCompanyInfoRO.id}`,
+      `http://rocketadmin-private-microservice:3001/saas/company/subscription/upgrade/${foundCompanyInfoRO.id}`,
       {
         method: 'POST',
         headers: {

--- a/backend/test/utils/send-request-to-saas-part.util.ts
+++ b/backend/test/utils/send-request-to-saas-part.util.ts
@@ -6,7 +6,7 @@ export async function sendRequestToSaasPart(
   requestBody: Record<string, any>,
   authCookieValue: string,
 ): Promise<Response> {
-  return await fetch(`http://rocketadmin-private-microservice:3001/${route}`, {
+  return await fetch(`http://rocketadmin-private-microservice:3001/saas/${route}`, {
     method,
     body: JSON.stringify(requestBody),
     headers: {


### PR DESCRIPTION
…ons' table in DB reset for end-to-end tests