### PR TITLE
Potential fix for code scanning alert no. 30: Use of externally-controlled format string

### DIFF
--- a/shared-code/src/data-access-layer/data-access-objects/data-access-object-oracle.ts
+++ b/shared-code/src/data-access-layer/data-access-objects/data-access-object-oracle.ts
@@ -148,7 +148,7 @@ export class DataAccessObjectOracle extends BasicDataAccessObject implements IDa
         .where(primaryKey)
         .del();
     } catch (error) {
-      console.error(`Error deleting row in table ${tableName}:`, error);
+      console.error('Error deleting row in table: %s', tableName, error);
       throw error;
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/rocket-admin/rocketadmin/security/code-scanning/30](https://github.com/rocket-admin/rocketadmin/security/code-scanning/30)

To fix the problem, we should avoid directly interpolating untrusted data into the format string of logging functions. Instead, use a static format string and pass the untrusted data as a separate argument. Specifically, in `console.error`, replace `` `Error deleting row in table ${tableName}:` `` with `"Error deleting row in table: %s"` and pass `tableName` as an argument. This ensures that any format specifiers in `tableName` are not interpreted by the logging function, and the output remains as intended.

Edit the file `shared-code/src/data-access-layer/data-access-objects/data-access-object-oracle.ts` at line 151, replacing the vulnerable log statement with a safe one.

No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
