### PR TITLE
fix: disable nginx proxy buffering to enable AI streaming responses

### DIFF
--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -18,7 +18,11 @@ server {
         add_header referrer-policy 'strict-origin-when-cross-origin';
   }
   location /api/ {
-	  proxy_pass http://localhost:3000/;
-    proxy_set_header Host            $host;
+    proxy_pass http://localhost:3000/;
+    proxy_set_header Host $host;
+    proxy_http_version 1.1;
+    proxy_set_header Connection '';
+    proxy_buffering off;
+    proxy_cache off;
   }
 }


### PR DESCRIPTION
Nginx was buffering the entire backend response before forwarding it to the client, preventing SSE streaming on the /ai/v4/request endpoint.