### PR TITLE
Backend ai insights permission

### DIFF
--- a/backend/src/entities/ai/user-ai-requests-v2.controller.ts
+++ b/backend/src/entities/ai/user-ai-requests-v2.controller.ts
@@ -20,7 +20,7 @@ import { Timeout, TimeoutDefaults } from '../../decorators/timeout.decorator.js'
 import { UserId } from '../../decorators/user-id.decorator.js';
 import { InTransactionEnum } from '../../enums/in-transaction.enum.js';
 import { ConnectionEditGuard } from '../../guards/connection-edit.guard.js';
-import { TableReadGuard } from '../../guards/table-read.guard.js';
+import { TableAiRequestGuard } from '../../guards/table-ai-request.guard.js';
 import { ValidationHelper } from '../../helpers/validators/validation-helper.js';
 import { SentryInterceptor } from '../../interceptors/sentry.interceptor.js';
 import { IAISettingsAndWidgetsCreation, IRequestInfoFromTableV2 } from './ai-use-cases.interface.js';
@@ -47,7 +47,7 @@ export class UserAIRequestsControllerV2 {
 		status: 201,
 		description: 'Returned info with conversation history saved.',
 	})
-	@UseGuards(TableReadGuard)
+	@UseGuards(TableAiRequestGuard)
 	@ApiBody({ type: RequestInfoFromTableBodyDTO })
 	@ApiQuery({ name: 'tableName', required: true, type: String })
 	@ApiQuery({ name: 'threadId', required: false, type: String })

--- a/backend/src/entities/cedar-authorization/cedar-action-map.ts
+++ b/backend/src/entities/cedar-authorization/cedar-action-map.ts
@@ -8,6 +8,7 @@ export enum CedarAction {
 	TableAdd = 'table:add',
 	TableEdit = 'table:edit',
 	TableDelete = 'table:delete',
+	TableAiRequest = 'table:ai-request',
 	DashboardRead = 'dashboard:read',
 	DashboardCreate = 'dashboard:create',
 	DashboardEdit = 'dashboard:edit',

--- a/backend/src/entities/cedar-authorization/cedar-permissions.service.ts
+++ b/backend/src/entities/cedar-authorization/cedar-permissions.service.ts
@@ -213,7 +213,17 @@ export class CedarPermissionsService implements IUserAccessRepository {
 	): Promise<ITablePermissionData> {
 		const ctx = await this.loadContext(connectionId, cognitoUserName);
 		if (!ctx) {
-			return { tableName, accessLevel: { visibility: false, readonly: false, add: false, delete: false, edit: false } };
+			return {
+				tableName,
+				accessLevel: {
+					visibility: false,
+					readonly: false,
+					add: false,
+					delete: false,
+					edit: false,
+					aiRequest: false,
+				},
+			};
 		}
 
 		return this.evaluateTablePermissions(cognitoUserName, connectionId, tableName, ctx);
@@ -386,6 +396,14 @@ export class CedarPermissionsService implements IUserAccessRepository {
 			ctx.policies,
 			entities,
 		);
+		const canAiRequest = this.evaluatePolicies(
+			userId,
+			CedarAction.TableAiRequest,
+			CedarResourceType.Table,
+			resourceId,
+			ctx.policies,
+			entities,
+		);
 
 		return {
 			tableName,
@@ -395,6 +413,7 @@ export class CedarPermissionsService implements IUserAccessRepository {
 				add: canAdd,
 				delete: canDelete,
 				edit: canEdit,
+				aiRequest: canAiRequest,
 			},
 		};
 	}

--- a/backend/src/entities/cedar-authorization/cedar-policy-generator.ts
+++ b/backend/src/entities/cedar-authorization/cedar-policy-generator.ts
@@ -153,6 +153,11 @@ export function generateCedarPolicyForGroup(
 				`permit(\n  principal,\n  action == RocketAdmin::Action::"table:delete",\n  resource == ${tableRef}\n);`,
 			);
 		}
+		if (access.aiRequest) {
+			policies.push(
+				`permit(\n  principal,\n  action == RocketAdmin::Action::"table:ai-request",\n  resource == ${tableRef}\n);`,
+			);
+		}
 	}
 
 	return policies.join('\n\n');

--- a/backend/src/entities/cedar-authorization/cedar-policy-parser.ts
+++ b/backend/src/entities/cedar-authorization/cedar-policy-parser.ts
@@ -66,7 +66,8 @@ export function parseCedarPolicyToClassicalPermissions(
 			case 'table:read':
 			case 'table:add':
 			case 'table:edit':
-			case 'table:delete': {
+			case 'table:delete':
+			case 'table:ai-request': {
 				const tableName = extractTableName(permit.resourceId, connectionId);
 				if (!tableName) break;
 				const tableEntry = getOrCreateTableEntry(tableMap, tableName);
@@ -227,6 +228,7 @@ function getOrCreateTableEntry(map: Map<string, ITablePermissionData>, tableName
 				add: false,
 				delete: false,
 				edit: false,
+				aiRequest: false,
 			},
 		};
 		map.set(tableName, entry);
@@ -247,6 +249,9 @@ function applyTableAction(entry: ITablePermissionData, action: string): void {
 			break;
 		case 'table:delete':
 			entry.accessLevel.delete = true;
+			break;
+		case 'table:ai-request':
+			entry.accessLevel.aiRequest = true;
 			break;
 	}
 }

--- a/backend/src/entities/cedar-authorization/cedar-schema.json
+++ b/backend/src/entities/cedar-authorization/cedar-schema.json
@@ -101,6 +101,12 @@
 					"resourceTypes": ["Table"]
 				}
 			},
+			"table:ai-request": {
+				"appliesTo": {
+					"principalTypes": ["User"],
+					"resourceTypes": ["Table"]
+				}
+			},
 			"dashboard:read": {
 				"appliesTo": {
 					"principalTypes": ["User"],

--- a/backend/src/entities/cedar-authorization/cedar-schema.ts
+++ b/backend/src/entities/cedar-authorization/cedar-schema.ts
@@ -110,6 +110,12 @@ export const CEDAR_SCHEMA = {
 					resourceTypes: ['Table'],
 				},
 			},
+			'table:ai-request': {
+				appliesTo: {
+					principalTypes: ['User'],
+					resourceTypes: ['Table'],
+				},
+			},
 			'dashboard:read': {
 				appliesTo: {
 					principalTypes: ['User'],

--- a/backend/src/entities/connection/use-cases/get-permissions-for-group-in-connection.use.case.ts
+++ b/backend/src/entities/connection/use-cases/get-permissions-for-group-in-connection.use.case.ts
@@ -4,8 +4,8 @@ import AbstractUseCase from '../../../common/abstract-use.case.js';
 import { IGlobalDatabaseContext } from '../../../common/application/global-database-context.interface.js';
 import { BaseType } from '../../../common/data-injection.tokens.js';
 import { AccessLevelEnum } from '../../../enums/access-level.enum.js';
-import { TablePermissionDs } from '../../permission/application/data-structures/create-permissions.ds.js';
 import { parseCedarPolicyToClassicalPermissions } from '../../cedar-authorization/cedar-policy-parser.js';
+import { TablePermissionDs } from '../../permission/application/data-structures/create-permissions.ds.js';
 import { FoundPermissionsInConnectionDs } from '../application/data-structures/found-permissions-in-connection.ds.js';
 import { GetPermissionsInConnectionDs } from '../application/data-structures/get-permissions-in-connection.ds.js';
 import { IGetPermissionsForGroupInConnection } from './use-cases.interfaces.js';
@@ -62,6 +62,7 @@ export class GetPermissionsForGroupInConnectionUseCase
 					edit: false,
 					readonly: false,
 					visibility: false,
+					aiRequest: false,
 				},
 			};
 		});

--- a/backend/src/entities/permission/application/data-structures/create-permissions.ds.ts
+++ b/backend/src/entities/permission/application/data-structures/create-permissions.ds.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsBoolean, IsEnum, IsString, IsUUID, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsEnum, IsOptional, IsString, IsUUID, ValidateNested } from 'class-validator';
 import { AccessLevelEnum } from '../../../../enums/access-level.enum.js';
 
 export class CreatePermissionsDs {
@@ -41,6 +41,11 @@ export class TableAccessLevelsDs {
 	@ApiProperty()
 	@IsBoolean()
 	visibility: boolean;
+
+	@ApiProperty({ required: false })
+	@IsOptional()
+	@IsBoolean()
+	aiRequest?: boolean;
 }
 
 export class TablePermissionDs {

--- a/backend/src/entities/permission/permission.interface.ts
+++ b/backend/src/entities/permission/permission.interface.ts
@@ -24,6 +24,7 @@ export interface ITableAccessLevel {
 	add: boolean;
 	delete: boolean;
 	edit: boolean;
+	aiRequest?: boolean;
 }
 
 export interface ITablePermissionData {

--- a/backend/src/guards/table-ai-request.guard.ts
+++ b/backend/src/guards/table-ai-request.guard.ts
@@ -1,0 +1,46 @@
+import { BadRequestException, CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { IRequestWithCognitoInfo } from '../authorization/cognito-decoded.interface.js';
+import { CedarAction } from '../entities/cedar-authorization/cedar-action-map.js';
+import { CedarAuthorizationService } from '../entities/cedar-authorization/cedar-authorization.service.js';
+import { Messages } from '../exceptions/text/messages.js';
+import { ValidationHelper } from '../helpers/validators/validation-helper.js';
+import { validateUuidByRegex } from './utils/validate-uuid-by-regex.js';
+
+@Injectable()
+export class TableAiRequestGuard implements CanActivate {
+	constructor(private readonly cedarAuthService: CedarAuthorizationService) {}
+
+	canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+		return new Promise(async (resolve, reject) => {
+			const request: IRequestWithCognitoInfo = context.switchToHttp().getRequest();
+			const cognitoUserName = request.decoded.sub;
+			const connectionId: string = request.params?.slug || request.params?.connectionId;
+			const tableName: string = request.query?.tableName;
+			if (!tableName) {
+				reject(new BadRequestException(Messages.TABLE_NAME_MISSING));
+				return;
+			}
+			if (!connectionId || (!validateUuidByRegex(connectionId) && !ValidationHelper.isValidNanoId(connectionId))) {
+				reject(new BadRequestException(Messages.CONNECTION_ID_MISSING));
+				return;
+			}
+
+			try {
+				const allowed = await this.cedarAuthService.validate({
+					userId: cognitoUserName,
+					action: CedarAction.TableAiRequest,
+					connectionId,
+					tableName,
+				});
+				if (allowed) {
+					resolve(true);
+					return;
+				}
+				reject(new ForbiddenException(Messages.DONT_HAVE_PERMISSIONS));
+			} catch (e) {
+				reject(e);
+			}
+		});
+	}
+}

--- a/backend/test/ava-tests/non-saas-tests/non-saas-ai-request-permission-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-ai-request-permission-e2e.test.ts
@@ -1,0 +1,370 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { faker } from '@faker-js/faker';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import test from 'ava';
+import { ValidationError } from 'class-validator';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+import { AICoreService } from '../../../src/ai-core/services/ai-core.service.js';
+import { ApplicationModule } from '../../../src/app.module.js';
+import { WinstonLogger } from '../../../src/entities/logging/winston-logger.js';
+import { AccessLevelEnum } from '../../../src/enums/access-level.enum.js';
+import { AllExceptionsFilter } from '../../../src/exceptions/all-exceptions.filter.js';
+import { ValidationException } from '../../../src/exceptions/custom-exceptions/validation-exception.js';
+import { Messages } from '../../../src/exceptions/text/messages.js';
+import { Cacher } from '../../../src/helpers/cache/cacher.js';
+import { DatabaseModule } from '../../../src/shared/database/database.module.js';
+import { DatabaseService } from '../../../src/shared/database/database.service.js';
+import { MockFactory } from '../../mock.factory.js';
+import { createTestPostgresTableWithSchema } from '../../utils/create-test-table.js';
+import { dropTestTables } from '../../utils/drop-test-tables.js';
+import { getTestData } from '../../utils/get-test-data.js';
+import {
+	createInitialTestUser,
+	inviteUserInCompanyAndAcceptInvitation,
+	registerUserAndReturnUserInfo,
+} from '../../utils/register-user-and-return-user-info.js';
+import { setSaasEnvVariable } from '../../utils/set-saas-env-variable.js';
+import { TestUtils } from '../../utils/test.utils.js';
+
+const mockFactory = new MockFactory();
+let app: INestApplication;
+let _testUtils: TestUtils;
+const testTables: Array<string> = [];
+
+function createMockAIStream(content: string) {
+	return {
+		*[Symbol.asyncIterator]() {
+			yield { type: 'text', content, responseId: faker.string.uuid() };
+		},
+	};
+}
+
+const mockAICoreService = {
+	streamChatWithToolsAndProvider: async () => createMockAIStream('This is a mocked AI response for testing.'),
+	complete: async () => 'Mocked completion',
+	chat: async () => ({ content: 'Mocked chat', responseId: faker.string.uuid() }),
+	streamChat: async () => createMockAIStream('Mocked stream'),
+	chatWithTools: async () => ({ content: 'Mocked tools', responseId: faker.string.uuid() }),
+	streamChatWithTools: async () => createMockAIStream('Mocked tools stream'),
+	getDefaultProvider: () => 'bedrock',
+	setDefaultProvider: () => {},
+	getAvailableProviders: () => [],
+};
+
+test.before(async () => {
+	setSaasEnvVariable();
+	process.env.CEDAR_AUTHORIZATION_ENABLED = 'true';
+	const moduleFixture = await Test.createTestingModule({
+		imports: [ApplicationModule, DatabaseModule],
+		providers: [DatabaseService, TestUtils],
+	})
+		.overrideProvider(AICoreService)
+		.useValue(mockAICoreService)
+		.compile();
+
+	_testUtils = moduleFixture.get<TestUtils>(TestUtils);
+
+	app = moduleFixture.createNestApplication();
+	app.use(cookieParser());
+	app.useGlobalFilters(new AllExceptionsFilter(app.get(WinstonLogger)));
+	app.useGlobalPipes(
+		new ValidationPipe({
+			exceptionFactory(validationErrors: ValidationError[] = []) {
+				return new ValidationException(validationErrors);
+			},
+		}),
+	);
+	await app.init();
+	await createInitialTestUser(app);
+	app.getHttpServer().listen(0);
+});
+
+test.after(async () => {
+	try {
+		const connectionToTestDB = getTestData(mockFactory).connectionToPostgresSchema;
+		await dropTestTables(testTables, connectionToTestDB);
+		await Cacher.clearAllCache();
+		delete process.env.CEDAR_AUTHORIZATION_ENABLED;
+		await app.close();
+	} catch (e) {
+		console.error('After tests error ' + e);
+	}
+});
+
+interface InvitedUserSetup {
+	adminToken: string;
+	invitedToken: string;
+	invitedEmail: string;
+	connectionId: string;
+	createdGroupId: string;
+	tableName: string;
+}
+
+async function setupInvitedUserInCustomGroup(tableAccessLevel: {
+	visibility: boolean;
+	readonly: boolean;
+	add: boolean;
+	delete: boolean;
+	edit: boolean;
+	aiRequest?: boolean;
+}): Promise<InvitedUserSetup> {
+	const connectionToTestDB = getTestData(mockFactory).connectionToPostgresSchema;
+	const adminInfo = await registerUserAndReturnUserInfo(app);
+	const adminToken = adminInfo.token;
+
+	const invitedUserInfo = await inviteUserInCompanyAndAcceptInvitation(adminToken, undefined, app, undefined);
+	const invitedToken = invitedUserInfo.token;
+	const invitedEmail = invitedUserInfo.email;
+
+	const { testTableName } = await createTestPostgresTableWithSchema(connectionToTestDB);
+	testTables.push(testTableName);
+
+	const createConnectionResponse = await request(app.getHttpServer())
+		.post('/connection')
+		.send(connectionToTestDB)
+		.set('Cookie', adminToken)
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json');
+
+	if (createConnectionResponse.status >= 300) {
+		throw new Error(`connection creation failed: ${createConnectionResponse.text}`);
+	}
+	const connectionRO = JSON.parse(createConnectionResponse.text);
+	const connectionId = connectionRO.id;
+
+	await request(app.getHttpServer())
+		.post(`/connection/properties/${connectionId}`)
+		.send({ allow_ai_requests: true })
+		.set('Cookie', adminToken)
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json');
+
+	const newGroup = mockFactory.generateCreateGroupDto1();
+	const createGroupResponse = await request(app.getHttpServer())
+		.post(`/connection/group/${connectionId}`)
+		.set('Cookie', adminToken)
+		.send(newGroup)
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json');
+	const createdGroupId = JSON.parse(createGroupResponse.text).id;
+
+	const permissions = {
+		connection: {
+			connectionId,
+			accessLevel: AccessLevelEnum.readonly,
+		},
+		group: {
+			groupId: createdGroupId,
+			accessLevel: AccessLevelEnum.none,
+		},
+		tables: [
+			{
+				tableName: testTableName,
+				accessLevel: tableAccessLevel,
+			},
+		],
+	};
+
+	await request(app.getHttpServer())
+		.put(`/permissions/${createdGroupId}?connectionId=${connectionId}`)
+		.send({ permissions })
+		.set('Cookie', adminToken)
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json');
+
+	await request(app.getHttpServer())
+		.put('/group/user')
+		.set('Cookie', adminToken)
+		.send({ groupId: createdGroupId, email: invitedEmail })
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json');
+
+	return {
+		adminToken,
+		invitedToken,
+		invitedEmail,
+		connectionId,
+		createdGroupId,
+		tableName: testTableName,
+	};
+}
+
+const currentTest = 'POST /ai/v4/request/:connectionId (table:ai-request permission)';
+
+test.serial(`${currentTest} should allow request when admin (main) group user calls AI`, async (t) => {
+	try {
+		const connectionToTestDB = getTestData(mockFactory).connectionToPostgresSchema;
+		const { token } = await registerUserAndReturnUserInfo(app);
+		const { testTableName } = await createTestPostgresTableWithSchema(connectionToTestDB);
+		testTables.push(testTableName);
+
+		const createConnectionResponse = await request(app.getHttpServer())
+			.post('/connection')
+			.send(connectionToTestDB)
+			.set('Cookie', token)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+		t.is(createConnectionResponse.status, 201);
+		const connectionRO = JSON.parse(createConnectionResponse.text);
+
+		await request(app.getHttpServer())
+			.post(`/connection/properties/${connectionRO.id}`)
+			.send({ allow_ai_requests: true })
+			.set('Cookie', token)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		const aiRequestResponse = await request(app.getHttpServer())
+			.post(`/ai/v4/request/${connectionRO.id}?tableName=${testTableName}`)
+			.send({ user_message: 'Show me all records' })
+			.set('Cookie', token)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		t.is(aiRequestResponse.status, 201);
+	} catch (e) {
+		console.error(e);
+		throw e;
+	}
+});
+
+test.serial(
+	`${currentTest} should reject request when invited user has table:read but no table:ai-request`,
+	async (t) => {
+		try {
+			const setup = await setupInvitedUserInCustomGroup({
+				visibility: true,
+				readonly: true,
+				add: false,
+				delete: false,
+				edit: false,
+			});
+
+			const aiRequestResponse = await request(app.getHttpServer())
+				.post(`/ai/v4/request/${setup.connectionId}?tableName=${setup.tableName}`)
+				.send({ user_message: 'Show me all records' })
+				.set('Cookie', setup.invitedToken)
+				.set('Content-Type', 'application/json')
+				.set('Accept', 'application/json');
+
+			t.is(aiRequestResponse.status, 403);
+			const body = JSON.parse(aiRequestResponse.text);
+			t.is(body.message, Messages.DONT_HAVE_PERMISSIONS);
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	},
+);
+
+test.serial(
+	`${currentTest} should reject request when invited user has table:edit but no table:ai-request`,
+	async (t) => {
+		try {
+			const setup = await setupInvitedUserInCustomGroup({
+				visibility: true,
+				readonly: false,
+				add: true,
+				delete: true,
+				edit: true,
+			});
+
+			const aiRequestResponse = await request(app.getHttpServer())
+				.post(`/ai/v4/request/${setup.connectionId}?tableName=${setup.tableName}`)
+				.send({ user_message: 'Show me all records' })
+				.set('Cookie', setup.invitedToken)
+				.set('Content-Type', 'application/json')
+				.set('Accept', 'application/json');
+
+			t.is(aiRequestResponse.status, 403);
+			const body = JSON.parse(aiRequestResponse.text);
+			t.is(body.message, Messages.DONT_HAVE_PERMISSIONS);
+		} catch (e) {
+			console.error(e);
+			throw e;
+		}
+	},
+);
+
+test.serial(`${currentTest} should allow request when invited user has table:ai-request granted`, async (t) => {
+	try {
+		const setup = await setupInvitedUserInCustomGroup({
+			visibility: true,
+			readonly: true,
+			add: false,
+			delete: false,
+			edit: false,
+			aiRequest: true,
+		});
+
+		const aiRequestResponse = await request(app.getHttpServer())
+			.post(`/ai/v4/request/${setup.connectionId}?tableName=${setup.tableName}`)
+			.send({ user_message: 'Show me all records' })
+			.set('Cookie', setup.invitedToken)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		t.is(aiRequestResponse.status, 201);
+	} catch (e) {
+		console.error(e);
+		throw e;
+	}
+});
+
+test.serial(`${currentTest} should reject request when invited user has no table permissions at all`, async (t) => {
+	try {
+		const connectionToTestDB = getTestData(mockFactory).connectionToPostgresSchema;
+		const adminInfo = await registerUserAndReturnUserInfo(app);
+		const adminToken = adminInfo.token;
+		const invitedUserInfo = await inviteUserInCompanyAndAcceptInvitation(adminToken, undefined, app, undefined);
+
+		const { testTableName } = await createTestPostgresTableWithSchema(connectionToTestDB);
+		testTables.push(testTableName);
+
+		const createConnectionResponse = await request(app.getHttpServer())
+			.post('/connection')
+			.send(connectionToTestDB)
+			.set('Cookie', adminToken)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+		t.is(createConnectionResponse.status, 201);
+		const connectionRO = JSON.parse(createConnectionResponse.text);
+
+		await request(app.getHttpServer())
+			.post(`/connection/properties/${connectionRO.id}`)
+			.send({ allow_ai_requests: true })
+			.set('Cookie', adminToken)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		const newGroup = mockFactory.generateCreateGroupDto1();
+		const createGroupResponse = await request(app.getHttpServer())
+			.post(`/connection/group/${connectionRO.id}`)
+			.set('Cookie', adminToken)
+			.send(newGroup)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+		const createdGroupId = JSON.parse(createGroupResponse.text).id;
+
+		await request(app.getHttpServer())
+			.put('/group/user')
+			.set('Cookie', adminToken)
+			.send({ groupId: createdGroupId, email: invitedUserInfo.email })
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		const aiRequestResponse = await request(app.getHttpServer())
+			.post(`/ai/v4/request/${connectionRO.id}?tableName=${testTableName}`)
+			.send({ user_message: 'Show me all records' })
+			.set('Cookie', invitedUserInfo.token)
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json');
+
+		t.is(aiRequestResponse.status, 403);
+	} catch (e) {
+		console.error(e);
+		throw e;
+	}
+});

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-cassandra.e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-cassandra.e2e.test.ts
@@ -110,7 +110,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-ibmdb2-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-ibmdb2-e2e.test.ts
@@ -110,7 +110,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-mongodb-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-mongodb-e2e.test.ts
@@ -109,7 +109,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-mssql-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-mssql-e2e.test.ts
@@ -105,7 +105,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-mssql-schema-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-mssql-schema-e2e.test.ts
@@ -106,7 +106,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-mysql-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-mysql-e2e.test.ts
@@ -105,7 +105,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-oracledb-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-oracledb-e2e.test.ts
@@ -107,7 +107,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-oracledb-schema-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-oracledb-schema-e2e.test.ts
@@ -107,7 +107,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-postgres-encrypted-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-postgres-encrypted-e2e.test.ts
@@ -107,7 +107,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-postgres-schema-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-postgres-schema-e2e.test.ts
@@ -105,7 +105,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/non-saas-tests/non-saas-table-redis-e2e.test.ts
+++ b/backend/test/ava-tests/non-saas-tests/non-saas-table-redis-e2e.test.ts
@@ -109,7 +109,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/api-key-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/api-key-e2e.test.ts
@@ -106,7 +106,7 @@ test.serial(`${currentTest} should return created api key for this user`, async 
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/connection-properties-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/connection-properties-e2e.test.ts
@@ -337,7 +337,7 @@ test.serial(
 		t.is(Object.hasOwn(findTablesRO.tables[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(findTablesRO.tables[testTableIndex], 'permissions'), true);
 		t.is(typeof findTablesRO.tables[testTableIndex].permissions, 'object');
-		t.is(Object.keys(findTablesRO.tables[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(findTablesRO.tables[testTableIndex].permissions).length, 6);
 		t.is(findTablesRO.tables[testTableIndex].table, testTableName);
 		t.is(findTablesRO.tables[testTableIndex].permissions.visibility, true);
 		t.is(findTablesRO.tables[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-cassandra-agent.e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-cassandra-agent.e2e.test.ts
@@ -118,7 +118,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-cassandra.e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-cassandra.e2e.test.ts
@@ -103,7 +103,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-clickhouse-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-clickhouse-agent-e2e.test.ts
@@ -116,7 +116,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-clickhouse-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-clickhouse-e2e.test.ts
@@ -104,7 +104,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-dynamodb-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-dynamodb-e2e.test.ts
@@ -97,7 +97,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 	t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 	t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 	t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-	t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+	t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 	t.is(getTablesRO[testTableIndex].table, testTableName);
 	t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 	t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-elasticsearch-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-elasticsearch-e2e.test.ts
@@ -102,7 +102,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-ibmdb2-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-ibmdb2-agent-e2e.test.ts
@@ -124,7 +124,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-ibmdb2-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-ibmdb2-e2e.test.ts
@@ -103,7 +103,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-mongodb-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-mongodb-agent-e2e.test.ts
@@ -116,7 +116,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-mongodb-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-mongodb-e2e.test.ts
@@ -102,7 +102,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-mssql-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-mssql-agent-e2e.test.ts
@@ -164,7 +164,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-mssql-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-mssql-e2e.test.ts
@@ -106,7 +106,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-mssql-schema-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-mssql-schema-e2e.test.ts
@@ -98,7 +98,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-mysql-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-mysql-agent-e2e.test.ts
@@ -160,7 +160,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-mysql-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-mysql-e2e.test.ts
@@ -106,7 +106,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-oracle-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-oracle-agent-e2e.test.ts
@@ -160,7 +160,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-oracledb-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-oracledb-e2e.test.ts
@@ -107,7 +107,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-oracledb-schema-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-oracledb-schema-e2e.test.ts
@@ -101,7 +101,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-postgres-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-postgres-agent-e2e.test.ts
@@ -162,7 +162,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-postgres-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-postgres-e2e.test.ts
@@ -105,7 +105,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-postgres-encrypted-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-postgres-encrypted-e2e.test.ts
@@ -101,7 +101,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-postgres-schema-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-postgres-schema-e2e.test.ts
@@ -99,7 +99,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-redis-agent-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-redis-agent-e2e.test.ts
@@ -117,7 +117,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);

--- a/backend/test/ava-tests/saas-tests/table-redis-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/table-redis-e2e.test.ts
@@ -102,7 +102,7 @@ test.serial(`${currentTest} should return list of tables in connection`, async (
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'table'), true);
 		t.is(Object.hasOwn(getTablesRO[testTableIndex], 'permissions'), true);
 		t.is(typeof getTablesRO[testTableIndex].permissions, 'object');
-		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 5);
+		t.is(Object.keys(getTablesRO[testTableIndex].permissions).length, 6);
 		t.is(getTablesRO[testTableIndex].table, testTableName);
 		t.is(getTablesRO[testTableIndex].permissions.visibility, true);
 		t.is(getTablesRO[testTableIndex].permissions.readonly, false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `aiRequest` permission flag to table-level access controls, enabling granular control over who can make AI requests on specific tables.

* **Updates**
  * Extended authorization system with new `table:ai-request` action for Cedar-based permission evaluation.
  * Updated permission schema across the system to reflect the new permission field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->