### PR TITLE
feat: add invalidateMetadataCache method to data access objects and update usage in GetConnectionDiagramUseCase

### DIFF
--- a/backend/src/entities/connection/use-cases/get-connection-diagram.use.case.ts
+++ b/backend/src/entities/connection/use-cases/get-connection-diagram.use.case.ts
@@ -46,6 +46,7 @@ export class GetConnectionDiagramUseCase
 			: undefined;
 
 		await validateSchemaCache(dao, userEmail);
+		dao.invalidateMetadataCache();
 
 		let tables: Array<{ tableName: string; isView: boolean }>;
 		try {

--- a/shared-code/src/data-access-layer/data-access-objects/basic-data-access-object.ts
+++ b/shared-code/src/data-access-layer/data-access-objects/basic-data-access-object.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex';
+import { LRUStorage } from '../../caching/lru-storage.js';
 import { isObjectEmpty } from '../../helpers/is-object-empty.js';
 import { KnexManager } from '../../knex-manager/knex-manager.js';
 import { ConnectionParams } from '../shared/data-structures/connections-params.ds.js';
@@ -11,6 +12,11 @@ export class BasicDataAccessObject {
 	constructor(connection: ConnectionParams) {
 		this.connection = connection;
 	}
+
+	public invalidateMetadataCache(): void {
+		LRUStorage.invalidateConnectionTableMetadata(this.connection);
+	}
+
 	protected async configureKnex(): Promise<Knex<any, any[]>> {
 		const knexManager = KnexManager.knexStorage();
 		return knexManager.get(this.connection.type)(this.connection);

--- a/shared-code/src/data-access-layer/data-access-objects/data-access-object-agent.ts
+++ b/shared-code/src/data-access-layer/data-access-objects/data-access-object-agent.ts
@@ -40,6 +40,10 @@ export class DataAccessObjectAgent implements IDataAccessObjectAgent {
 		this.connection = connection;
 	}
 
+	public invalidateMetadataCache(): void {
+		LRUStorage.invalidateConnectionTableMetadata(this.connection);
+	}
+
 	public async addRowInTable(
 		tableName: string,
 		row: Record<string, unknown>,

--- a/shared-code/src/shared/interfaces/data-access-object-agent.interface.ts
+++ b/shared-code/src/shared/interfaces/data-access-object-agent.interface.ts
@@ -68,6 +68,8 @@ export interface IDataAccessObjectAgent {
 
 	getTableStructureWithoutCache(tableName: string, userEmail: string): Promise<Array<TableStructureDS>>;
 
+	invalidateMetadataCache(): void;
+
 	testConnect(): Promise<TestConnectionResultDS>;
 
 	updateRowInTable(

--- a/shared-code/src/shared/interfaces/data-access-object.interface.ts
+++ b/shared-code/src/shared/interfaces/data-access-object.interface.ts
@@ -56,6 +56,8 @@ export interface IDataAccessObject {
 
 	getTableStructureWithoutCache(tableName: string): Promise<Array<TableStructureDS>>;
 
+	invalidateMetadataCache(): void;
+
 	testConnect(): Promise<TestConnectionResultDS>;
 
 	updateRowInTable(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation mechanisms for connection and table metadata to ensure connection diagrams consistently reflect the current state of database structures and configurations.
  * Enhanced metadata cache management across data access operations to provide improved data freshness and reliability when retrieving connection information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocket-admin/rocketadmin/pull/1771)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->