### PR TITLE
fix: copy frontend/browserslist into Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 ARG SAAS
 SHELL ["/bin/bash", "-c"]
 WORKDIR /app/frontend
-COPY frontend/package.json frontend/yarn.lock frontend/angular.json frontend/browserslist frontend/tsconfig.app.json frontend/tsconfig.json /app/frontend/
+COPY frontend/package.json frontend/yarn.lock frontend/.yarnrc.yml frontend/angular.json frontend/browserslist frontend/tsconfig.app.json frontend/tsconfig.json /app/frontend/
 COPY frontend/.yarn /app/frontend/.yarn
 RUN apt-get update && apt-get install -y \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG VERSION
 ARG SAAS
 SHELL ["/bin/bash", "-c"]
 WORKDIR /app/frontend
-COPY frontend/package.json frontend/yarn.lock frontend/angular.json frontend/tsconfig.app.json frontend/tsconfig.json /app/frontend/
+COPY frontend/package.json frontend/yarn.lock frontend/angular.json frontend/browserslist frontend/tsconfig.app.json frontend/tsconfig.json /app/frontend/
 COPY frontend/.yarn /app/frontend/.yarn
 RUN apt-get update && apt-get install -y \
     git \


### PR DESCRIPTION
Without this file present in /app/frontend during the production build, Angular falls back to the default browserslist (broader, older browser targets), which forces extra transpilation and inflates the initial bundle past the 5MB budget. Copying the committed browserslist preserves the intended modern targets and keeps the bundle within budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to optimize build layer caching, improving build efficiency for development and deployment pipelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocket-admin/rocketadmin/pull/1781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->