### PR TITLE
permissions: skip /permissions/available fetch on unauthenticated pages

### DIFF
--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
-import { ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatMenuModule } from '@angular/material/menu';
@@ -44,9 +44,12 @@ describe('AppComponent', () => {
 	const authCast = new Subject<any>();
 	const userCast = new Subject<any>();
 
+	const isAuthenticatedSignal = signal(false);
 	const mockAuthService = {
 		cast: authCast,
 		logOutUser: vi.fn().mockReturnValue(of(true)),
+		isAuthenticated: isAuthenticatedSignal.asReadonly(),
+		setAuthenticated: (value: boolean) => isAuthenticatedSignal.set(value),
 	};
 
 	const mockUserService = {

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -215,6 +215,7 @@ export class AppComponent {
 					localStorage.setItem('token_expiration', expirationTime.toISOString());
 					expirationToken = expirationTime.toISOString();
 				}
+				this._auth.setAuthenticated(true);
 
 				this.router.navigate(['/connections-list']);
 
@@ -236,6 +237,7 @@ export class AppComponent {
 					const expirationInterval = differenceInMilliseconds(expirationTime, currantTime);
 					console.log('expirationInterval', expirationInterval);
 					if (expirationInterval > 0) {
+						this._auth.setAuthenticated(true);
 						console.log('App component, session restoration');
 						this.initializeUserSession();
 
@@ -355,6 +357,7 @@ export class AppComponent {
 			this._user.setIsDemo(false);
 			this.currentUser = null;
 			localStorage.removeItem('token_expiration');
+			this._auth.setAuthenticated(false);
 			this.router.navigate(['/registration']);
 		});
 	}
@@ -375,6 +378,7 @@ export class AppComponent {
 		this._auth.logOutUser().subscribe(() => {
 			this.setUserLoggedIn(null);
 			localStorage.removeItem('token_expiration');
+			this._auth.setAuthenticated(false);
 
 			if (this.isSaas) {
 				if (!isTokenExpired) window.location.href = 'https://rocketadmin.com/';

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import * as Sentry from '@sentry/angular';
 import { BehaviorSubject, EMPTY } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -16,11 +16,18 @@ export class AuthService {
 	private auth = new BehaviorSubject<any>('');
 	public cast = this.auth.asObservable();
 
+	private _isAuthenticated = signal<boolean>(AuthService._hasValidSessionToken());
+	public readonly isAuthenticated = this._isAuthenticated.asReadonly();
+
 	constructor(
 		private _http: HttpClient,
 		private _notifications: NotificationsService,
 		private _configuration: ConfigurationService,
 	) {}
+
+	setAuthenticated(value: boolean): void {
+		this._isAuthenticated.set(value);
+	}
 
 	signUpUser(userData: NewAuthUser) {
 		const config = this._configuration.getConfig();
@@ -327,5 +334,12 @@ export class AuthService {
 				return EMPTY;
 			}),
 		);
+	}
+
+	private static _hasValidSessionToken(): boolean {
+		const exp = localStorage.getItem('token_expiration');
+		if (!exp) return false;
+		const expiration = new Date(exp);
+		return !isNaN(expiration.getTime()) && expiration.getTime() > Date.now();
 	}
 }

--- a/frontend/src/app/services/users.service.ts
+++ b/frontend/src/app/services/users.service.ts
@@ -5,6 +5,7 @@ import { PolicyAction, PolicyActionGroup } from 'src/app/lib/cedar-policy-items'
 import { groupNameForAction, PERMISSION_GROUP_ORDER } from 'src/app/lib/permission-display';
 import { GroupUser, Permissions, UserGroup, UserGroupInfo } from 'src/app/models/user';
 import { ApiService } from './api.service';
+import { AuthService } from './auth.service';
 import { NotificationsService } from './notifications.service';
 
 export type GroupUpdateEvent =
@@ -21,6 +22,7 @@ export type GroupUpdateEvent =
 })
 export class UsersService {
 	private _api = inject(ApiService);
+	private _auth = inject(AuthService);
 	private _http = inject(HttpClient);
 	private _notifications = inject(NotificationsService);
 
@@ -48,7 +50,7 @@ export class UsersService {
 
 	private _availablePermissionsResource: HttpResourceRef<{ actions: PolicyAction[] } | undefined> = this._api.resource<{
 		actions: PolicyAction[];
-	}>(() => '/permissions/available');
+	}>(() => (this._auth.isAuthenticated() ? '/permissions/available' : undefined));
 
 	public readonly availablePermissions = computed<PolicyAction[]>(
 		() => this._availablePermissionsResource.value()?.actions ?? [],


### PR DESCRIPTION
UsersService is provided in root and eagerly creates an httpResource for /permissions/available, which auto-fires on app bootstrap before any auth check, leaking a 401 request from /login and other unauthenticated pages. Gate the request function on a new isAuthenticated signal in AuthService — seeded from the existing localStorage 'token_expiration' and flipped via setAuthenticated() at the login, session-restoration, and logout transitions already managed by AppComponent. Mirrors the connection-id gating used by the other httpResource-backed services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable authentication state updates during login, session restore, and logout.
  * Improved session token validation to reduce unexpected sign-outs.

* **Behavior Change**
  * Available permissions now load only when signed in, preventing unauthorized/empty permission views.

* **Tests**
  * Unit tests updated to reflect the revised authentication behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocket-admin/rocketadmin/pull/1808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->