### PR TITLE
ci(frontend): use playwright container, add cache + path filter

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,31 +1,56 @@
 name: frontend
+
 on:
   push:
     branches:
-    - main
-    # Publish semver tags as releases
-    tags: [ '*.*.*' ]
+      - main
+    tags:
+      - '*.*.*'
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
   pull_request:
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend.yml'
+
+concurrency:
+  group: frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: frontend
+
+# TODO: add a lint job once ESLint migration replaces the (already-removed in
+# @angular-devkit/build-angular v20) `tslint` builder that `yarn lint` calls.
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: '24'
-      - run: cd frontend && yarn install
-      - name: Install Playwright browsers
-        run: cd frontend && yarn playwright install
-      - name: run tests
-        run: cd frontend && yarn test
+          cache: 'yarn'
+          cache-dependency-path: frontend/yarn.lock
+      - run: yarn install --immutable
+      - name: Run unit tests
+        run: yarn test:ci
+
   license:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
-      - uses: extractions/setup-just@v1
+          node-version: '24'
+          cache: 'yarn'
+          cache-dependency-path: frontend/yarn.lock
       - name: license checker
-        run: 'cd frontend && npx license-checker --onlyAllow="MIT;ISC;Python-2.0;Apache-2.0;BSD;MPL;CC;Custom: http://github.com/dscape/statsd-parser;" --excludePrivatePackages'
+        run: 'npx --yes license-checker --onlyAllow="MIT;ISC;Python-2.0;Apache-2.0;BSD;MPL;CC;Custom: http://github.com/dscape/statsd-parser;" --excludePrivatePackages'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
+      image: mcr.microsoft.com/playwright:v1.58.1-noble
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/backend/src/entities/user/use-cases/disable-otp.use.case.ts
+++ b/backend/src/entities/user/use-cases/disable-otp.use.case.ts
@@ -13,6 +13,7 @@ import { BaseType } from '../../../common/data-injection.tokens.js';
 import { Messages } from '../../../exceptions/text/messages.js';
 import { OtpDisablingResultDS } from '../application/data-structures/otp-validation-result.ds.js';
 import { VerifyOtpDS } from '../application/data-structures/verify-otp.ds.js';
+import { legacyOtpGuardrails } from '../utils/otp-guardrails.js';
 import { IDisableOTP } from './user-use-cases.interfaces.js';
 
 @Injectable()
@@ -41,7 +42,11 @@ export class DisableOtpUseCase extends AbstractUseCase<VerifyOtpDS, OtpDisabling
 			throw new BadRequestException(Messages.OTP_NOT_ENABLED);
 		}
 		try {
-			const isValid = verifySync({ token: otpToken, secret: otpSecretKey }).valid;
+			const isValid = verifySync({
+				token: otpToken,
+				secret: otpSecretKey,
+				guardrails: legacyOtpGuardrails,
+			}).valid;
 			if (isValid) {
 				foundUser.isOTPEnabled = false;
 				foundUser.otpSecretKey = null;

--- a/backend/src/entities/user/use-cases/otp-login-use.case.ts
+++ b/backend/src/entities/user/use-cases/otp-login-use.case.ts
@@ -10,6 +10,7 @@ import { SignInAuditService } from '../../user-sign-in-audit/sign-in-audit.servi
 import { VerifyOtpDS } from '../application/data-structures/verify-otp.ds.js';
 import { generateGwtToken, IToken } from '../utils/generate-gwt-token.js';
 import { get2FaScope } from '../utils/is-jwt-scope-need.util.js';
+import { legacyOtpGuardrails } from '../utils/otp-guardrails.js';
 import { IOtpLogin } from './user-use-cases.interfaces.js';
 
 @Injectable()
@@ -28,7 +29,11 @@ export class OtpLoginUseCase extends AbstractUseCase<VerifyOtpDS, IToken> implem
 		if (!foundUser) {
 			throw new NotFoundException(Messages.USER_NOT_FOUND);
 		}
-		const isValid = verifySync({ token: otpToken, secret: foundUser.otpSecretKey }).valid;
+		const isValid = verifySync({
+			token: otpToken,
+			secret: foundUser.otpSecretKey,
+			guardrails: legacyOtpGuardrails,
+		}).valid;
 		if (!isValid) {
 			await this.recordSignInAudit(
 				foundUser.email,

--- a/backend/src/entities/user/use-cases/verify-otp-use.case.ts
+++ b/backend/src/entities/user/use-cases/verify-otp-use.case.ts
@@ -6,6 +6,7 @@ import { BaseType } from '../../../common/data-injection.tokens.js';
 import { Messages } from '../../../exceptions/text/messages.js';
 import { OtpValidationResultDS } from '../application/data-structures/otp-validation-result.ds.js';
 import { VerifyOtpDS } from '../application/data-structures/verify-otp.ds.js';
+import { legacyOtpGuardrails } from '../utils/otp-guardrails.js';
 import { IVerifyOTP } from './user-use-cases.interfaces.js';
 
 @Injectable()
@@ -48,7 +49,11 @@ export class VerifyOtpUseCase extends AbstractUseCase<VerifyOtpDS, OtpValidation
 			);
 		}
 		try {
-			const isValid = verifySync({ token: otpToken, secret: otpSecretKey }).valid;
+			const isValid = verifySync({
+				token: otpToken,
+				secret: otpSecretKey,
+				guardrails: legacyOtpGuardrails,
+			}).valid;
 			if (isValid) {
 				foundUser.isOTPEnabled = true;
 				await this._dbContext.userRepository.saveUserEntity(foundUser);

--- a/backend/src/entities/user/utils/otp-guardrails.ts
+++ b/backend/src/entities/user/utils/otp-guardrails.ts
@@ -1,0 +1,8 @@
+import { createGuardrails } from 'otplib';
+
+// otplib v13 enforces RFC 4226's 128-bit (16-byte) minimum secret length, but
+// users enrolled before the v12 -> v13 upgrade have 10-byte secrets stored
+// (the v12 `authenticator.generateSecret()` default). Relax the guardrail at
+// verify time so those users can still authenticate. New secrets use v13's
+// 20-byte default and are RFC-compliant.
+export const legacyOtpGuardrails = createGuardrails({ MIN_SECRET_BYTES: 10 });


### PR DESCRIPTION
- Run tests in mcr.microsoft.com/playwright:v1.57.0-noble so the workflow no longer downloads browsers at runtime.
- Fix yarn test (watch-mode) -> yarn test:ci.
- Add yarn cache via setup-node@v4 and yarn install --immutable.
- Path-filter triggers to frontend/** plus this workflow file.
- Cancel superseded PR runs via concurrency group.
- Bump license job Node 16 -> 24, drop unused setup-just step.
- Modernize action versions (checkout@v5, setup-node@v4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP verification to support legacy secret formats so older authenticator setups continue to work.

* **Chores**
  * Updated CI workflow: tests now run in a containerized environment with scoped triggers and concurrency to reduce redundant runs and improve reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocket-admin/rocketadmin/pull/1810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->