### PR TITLE
refactor: remove unused schema change chat entities migration

### DIFF
--- a/backend/src/migrations/1778767036234-AddSchemaChangeChatEntities.ts
+++ b/backend/src/migrations/1778767036234-AddSchemaChangeChatEntities.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSchemaChangeChatEntities1778767036234 implements MigrationInterface {
+	name = 'AddSchemaChangeChatEntities1778767036234';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`CREATE TABLE "schema_change_chat" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP DEFAULT now(), "user_id" uuid NOT NULL, "connection_id" character varying(38) NOT NULL, "last_batch_id" uuid, CONSTRAINT "PK_60082e3e240c265fc043290381d" PRIMARY KEY ("id"))`,
+		);
+		await queryRunner.query(
+			`CREATE TYPE "public"."schema_change_chat_message_role_enum" AS ENUM('user', 'ai', 'system')`,
+		);
+		await queryRunner.query(
+			`CREATE TABLE "schema_change_chat_message" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "message" text, "role" "public"."schema_change_chat_message_role_enum", "batch_id" uuid, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP DEFAULT now(), "chat_id" uuid NOT NULL, CONSTRAINT "PK_5984cdb248fa9c2f55f5a19022c" PRIMARY KEY ("id"))`,
+		);
+		await queryRunner.query(`ALTER TABLE "ai_chat_message" DROP COLUMN "response_id"`);
+		await queryRunner.query(
+			`ALTER TABLE "schema_change_chat" ADD CONSTRAINT "FK_4dbf7dad457505747189fb98d7e" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE "schema_change_chat" ADD CONSTRAINT "FK_9f9acf0578fcf239576640d7b7b" FOREIGN KEY ("connection_id") REFERENCES "connection"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+		);
+		await queryRunner.query(
+			`ALTER TABLE "schema_change_chat_message" ADD CONSTRAINT "FK_32825f4780664738f60fa75cd50" FOREIGN KEY ("chat_id") REFERENCES "schema_change_chat"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+		);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(
+			`ALTER TABLE "schema_change_chat_message" DROP CONSTRAINT "FK_32825f4780664738f60fa75cd50"`,
+		);
+		await queryRunner.query(`ALTER TABLE "schema_change_chat" DROP CONSTRAINT "FK_9f9acf0578fcf239576640d7b7b"`);
+		await queryRunner.query(`ALTER TABLE "schema_change_chat" DROP CONSTRAINT "FK_4dbf7dad457505747189fb98d7e"`);
+		await queryRunner.query(`ALTER TABLE "ai_chat_message" ADD "response_id" character varying(255)`);
+		await queryRunner.query(`DROP TABLE "schema_change_chat_message"`);
+		await queryRunner.query(`DROP TYPE "public"."schema_change_chat_message_role_enum"`);
+		await queryRunner.query(`DROP TABLE "schema_change_chat"`);
+	}
+}

--- a/backend/src/migrations/1779975103808-AddAiAutoFixColumnsToTableSchemaChange.ts
+++ b/backend/src/migrations/1779975103808-AddAiAutoFixColumnsToTableSchemaChange.ts
@@ -4,44 +4,16 @@ export class AddAiAutoFixColumnsToTableSchemaChange1779975103808 implements Migr
 	name = 'AddAiAutoFixColumnsToTableSchemaChange1779975103808';
 
 	public async up(queryRunner: QueryRunner): Promise<void> {
-		await queryRunner.query(
-			`CREATE TYPE "public"."schema_change_chat_message_role_enum" AS ENUM('user', 'ai', 'system')`,
-		);
-		await queryRunner.query(
-			`CREATE TABLE "schema_change_chat_message" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "message" text, "role" "public"."schema_change_chat_message_role_enum", "batch_id" uuid, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP DEFAULT now(), "chat_id" uuid NOT NULL, CONSTRAINT "PK_5984cdb248fa9c2f55f5a19022c" PRIMARY KEY ("id"))`,
-		);
-		await queryRunner.query(
-			`CREATE TABLE "schema_change_chat" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "name" character varying, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP DEFAULT now(), "user_id" uuid NOT NULL, "connection_id" character varying(38) NOT NULL, "last_batch_id" uuid, CONSTRAINT "PK_60082e3e240c265fc043290381d" PRIMARY KEY ("id"))`,
-		);
-		await queryRunner.query(`ALTER TABLE "ai_chat_message" DROP COLUMN "response_id"`);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" ADD "aiAutoFixApplied" boolean NOT NULL DEFAULT false`);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" ADD "aiAutoFixOriginalForwardSql" text`);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" ADD "aiAutoFixOriginalRollbackSql" text`);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" ADD "aiAutoFixOriginalError" text`);
-		await queryRunner.query(
-			`ALTER TABLE "schema_change_chat_message" ADD CONSTRAINT "FK_32825f4780664738f60fa75cd50" FOREIGN KEY ("chat_id") REFERENCES "schema_change_chat"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
-		);
-		await queryRunner.query(
-			`ALTER TABLE "schema_change_chat" ADD CONSTRAINT "FK_4dbf7dad457505747189fb98d7e" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
-		);
-		await queryRunner.query(
-			`ALTER TABLE "schema_change_chat" ADD CONSTRAINT "FK_9f9acf0578fcf239576640d7b7b" FOREIGN KEY ("connection_id") REFERENCES "connection"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
-		);
 	}
 
 	public async down(queryRunner: QueryRunner): Promise<void> {
-		await queryRunner.query(`ALTER TABLE "schema_change_chat" DROP CONSTRAINT "FK_9f9acf0578fcf239576640d7b7b"`);
-		await queryRunner.query(`ALTER TABLE "schema_change_chat" DROP CONSTRAINT "FK_4dbf7dad457505747189fb98d7e"`);
-		await queryRunner.query(
-			`ALTER TABLE "schema_change_chat_message" DROP CONSTRAINT "FK_32825f4780664738f60fa75cd50"`,
-		);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" DROP COLUMN "aiAutoFixOriginalError"`);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" DROP COLUMN "aiAutoFixOriginalRollbackSql"`);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" DROP COLUMN "aiAutoFixOriginalForwardSql"`);
 		await queryRunner.query(`ALTER TABLE "table_schema_change" DROP COLUMN "aiAutoFixApplied"`);
-		await queryRunner.query(`ALTER TABLE "ai_chat_message" ADD "response_id" character varying(255)`);
-		await queryRunner.query(`DROP TABLE "schema_change_chat"`);
-		await queryRunner.query(`DROP TABLE "schema_change_chat_message"`);
-		await queryRunner.query(`DROP TYPE "public"."schema_change_chat_message_role_enum"`);
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database schema updated with new tables and relationships supporting schema change chat conversations, message storage, and links between user accounts and database connections.
  * Schema change records enhanced with AI auto-fix operation tracking, including columns for applied status, original SQL statements (forward and rollback), and error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->