### PR TITLE
feat: add createdAt timestamp to email verification and password reset entities

### DIFF
--- a/backend/src/entities/email/email-verification.entity.ts
+++ b/backend/src/entities/email/email-verification.entity.ts
@@ -9,6 +9,9 @@ export class EmailVerificationEntity {
 	@Column({ default: null })
 	verification_string: string;
 
+	@Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+	createdAt: Date;
+
 	@OneToOne(
 		() => UserEntity,
 		(user) => user.email_verification,

--- a/backend/src/entities/email/repository/email-verification-custom-repository-extension.ts
+++ b/backend/src/entities/email/repository/email-verification-custom-repository-extension.ts
@@ -1,3 +1,4 @@
+import { Constants } from '../../../helpers/constants/constants.js';
 import { Encryptor } from '../../../helpers/encryption/encryptor.js';
 import { UserEntity } from '../../user/user.entity.js';
 import { EmailVerificationEntity } from '../email-verification.entity.js';
@@ -8,6 +9,9 @@ export const emailVerificationRepositoryExtension = {
 			.leftJoinAndSelect('email_verification.user', 'user')
 			.where('email_verification.verification_string = :ver_string', {
 				ver_string: verificationString,
+			})
+			.andWhere('email_verification.createdAt >= :valid_after', {
+				valid_after: Constants.ONE_DAY_AGO(),
 			});
 		return await qb.getOne();
 	},

--- a/backend/src/entities/user/user-password/password-reset.entity.ts
+++ b/backend/src/entities/user/user-password/password-reset.entity.ts
@@ -9,6 +9,9 @@ export class PasswordResetEntity {
 	@Column({ default: null })
 	verification_string: string;
 
+	@Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+	createdAt: Date;
+
 	@OneToOne(
 		() => UserEntity,
 		(user) => user.password_reset,

--- a/backend/src/entities/user/user-password/repository/user-password-custom-repository-extension.ts
+++ b/backend/src/entities/user/user-password/repository/user-password-custom-repository-extension.ts
@@ -1,3 +1,4 @@
+import { Constants } from '../../../../helpers/constants/constants.js';
 import { Encryptor } from '../../../../helpers/encryption/encryptor.js';
 import { UserEntity } from '../../user.entity.js';
 import { PasswordResetEntity } from '../password-reset.entity.js';
@@ -8,6 +9,9 @@ export const userPasswordResetCustomRepositoryExtension = {
 			.leftJoinAndSelect('password_reset.user', 'user')
 			.where('password_reset.verification_string = :ver_string', {
 				ver_string: verificationString,
+			})
+			.andWhere('password_reset.createdAt >= :valid_after', {
+				valid_after: Constants.ONE_DAY_AGO(),
 			});
 		return await qb.getOne();
 	},

--- a/backend/src/migrations/1780411916141-AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities.ts
+++ b/backend/src/migrations/1780411916141-AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities1780411916141
+	implements MigrationInterface
+{
+	name = 'AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities1780411916141';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "email_verification" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`);
+		await queryRunner.query(`ALTER TABLE "password_reset" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "password_reset" DROP COLUMN "createdAt"`);
+		await queryRunner.query(`ALTER TABLE "email_verification" DROP COLUMN "createdAt"`);
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email verification codes now expire after 24 hours
  * Password reset codes now expire after 24 hours

<!-- end of auto-generated comment: release notes by coderabbit.ai -->