### PR TITLE
mobile: widgets page, AI panel, sidebar polish + quick-filter chips

### DIFF
--- a/backend/src/entities/company-info/company-info.controller.ts
+++ b/backend/src/entities/company-info/company-info.controller.ts
@@ -81,8 +81,8 @@ import {
 	IRemoveUserFromCompany,
 	IRevokeUserInvitationInCompany,
 	ISuspendUsersInCompany,
-	IUnsuspendUsersInCompany,
 	IToggleCompanyTestConnectionsMode,
+	IUnsuspendUsersInCompany,
 	IUpdateCompanyName,
 	IUpdateUsers2faStatusInCompany,
 	IUpdateUsersCompanyRoles,
@@ -173,6 +173,7 @@ export class CompanyInfoController {
 		description: 'Get company name by id.',
 		type: FoundCompanyNameDs,
 	})
+	@Throttle({ default: { limit: isTest() ? 200 : 10, ttl: 60000 } })
 	@Get('name/:companyId')
 	async getCompanyNameById(@Param('companyId') companyId: string): Promise<FoundCompanyNameDs> {
 		return await this.getCompanyNameUseCase.execute(companyId);

--- a/backend/src/entities/email/email-verification.entity.ts
+++ b/backend/src/entities/email/email-verification.entity.ts
@@ -9,6 +9,9 @@ export class EmailVerificationEntity {
 	@Column({ default: null })
 	verification_string: string;
 
+	@Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+	createdAt: Date;
+
 	@OneToOne(
 		() => UserEntity,
 		(user) => user.email_verification,

--- a/backend/src/entities/email/repository/email-verification-custom-repository-extension.ts
+++ b/backend/src/entities/email/repository/email-verification-custom-repository-extension.ts
@@ -1,3 +1,4 @@
+import { Constants } from '../../../helpers/constants/constants.js';
 import { Encryptor } from '../../../helpers/encryption/encryptor.js';
 import { UserEntity } from '../../user/user.entity.js';
 import { EmailVerificationEntity } from '../email-verification.entity.js';
@@ -8,6 +9,9 @@ export const emailVerificationRepositoryExtension = {
 			.leftJoinAndSelect('email_verification.user', 'user')
 			.where('email_verification.verification_string = :ver_string', {
 				ver_string: verificationString,
+			})
+			.andWhere('email_verification.createdAt >= :valid_after', {
+				valid_after: Constants.ONE_DAY_AGO(),
 			});
 		return await qb.getOne();
 	},

--- a/backend/src/entities/user/user-password/password-reset.entity.ts
+++ b/backend/src/entities/user/user-password/password-reset.entity.ts
@@ -9,6 +9,9 @@ export class PasswordResetEntity {
 	@Column({ default: null })
 	verification_string: string;
 
+	@Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+	createdAt: Date;
+
 	@OneToOne(
 		() => UserEntity,
 		(user) => user.password_reset,

--- a/backend/src/entities/user/user-password/repository/user-password-custom-repository-extension.ts
+++ b/backend/src/entities/user/user-password/repository/user-password-custom-repository-extension.ts
@@ -1,3 +1,4 @@
+import { Constants } from '../../../../helpers/constants/constants.js';
 import { Encryptor } from '../../../../helpers/encryption/encryptor.js';
 import { UserEntity } from '../../user.entity.js';
 import { PasswordResetEntity } from '../password-reset.entity.js';
@@ -8,6 +9,9 @@ export const userPasswordResetCustomRepositoryExtension = {
 			.leftJoinAndSelect('password_reset.user', 'user')
 			.where('password_reset.verification_string = :ver_string', {
 				ver_string: verificationString,
+			})
+			.andWhere('password_reset.createdAt >= :valid_after', {
+				valid_after: Constants.ONE_DAY_AGO(),
 			});
 		return await qb.getOne();
 	},

--- a/backend/src/entities/visualizations/panel/utils/check-query-is-safe.util.ts
+++ b/backend/src/entities/visualizations/panel/utils/check-query-is-safe.util.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from '@nestjs/common';
 import { ConnectionTypesEnum } from '@rocketadmin/shared-code/dist/src/shared/enums/connection-types-enum.js';
+import { isReadOnlyMongoAggregationPipeline } from '../../../../ai-core/tools/query-validators.js';
 import { slackPostMessage } from '../../../../helpers/slack/slack-post-message.js';
 
 const FORBIDDEN_SQL_KEYWORDS = [
@@ -173,6 +174,14 @@ export function checkMongoQueryIsSafe(query: string): QuerySafetyResult {
 				forbiddenKeyword: operation,
 			};
 		}
+	}
+
+	if (!isReadOnlyMongoAggregationPipeline(query)) {
+		return {
+			isSafe: false,
+			reason:
+				'Query must be a read-only aggregation pipeline (write stages or server-side JavaScript operators such as $out, $merge, $function, $accumulator, $where are not allowed)',
+		};
 	}
 
 	return { isSafe: true };

--- a/backend/src/migrations/1780411916141-AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities.ts
+++ b/backend/src/migrations/1780411916141-AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities1780411916141
+	implements MigrationInterface
+{
+	name = 'AddCreatedAtColumnsIntoPasswordResetAndEmailVerificationEntities1780411916141';
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "email_verification" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`);
+		await queryRunner.query(`ALTER TABLE "password_reset" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(`ALTER TABLE "password_reset" DROP COLUMN "createdAt"`);
+		await queryRunner.query(`ALTER TABLE "email_verification" DROP COLUMN "createdAt"`);
+	}
+}

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -75,8 +75,8 @@
 								},
 								{
 									"type": "anyComponentStyle",
-									"maximumWarning": "10kb",
-									"maximumError": "20kb"
+									"maximumWarning": "20kb",
+									"maximumError": "32kb"
 								}
 							]
 						},
@@ -129,8 +129,8 @@
 								},
 								{
 									"type": "anyComponentStyle",
-									"maximumWarning": "10kb",
-									"maximumError": "20kb"
+									"maximumWarning": "20kb",
+									"maximumError": "32kb"
 								}
 							]
 						}

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -22,6 +22,34 @@
 	width: 60vw;
 }
 
+.main-menu-sidenav .account-section-item {
+	--mdc-list-list-item-label-text-size: 13px;
+	--mat-list-list-item-leading-icon-size: 18px;
+	--mdc-list-list-item-one-line-container-height: 40px;
+	--mdc-list-list-item-two-line-container-height: 52px;
+}
+
+.main-menu-sidenav .account-section-item .mat-icon {
+	font-size: 18px;
+	width: 18px;
+	height: 18px;
+}
+
+@media (width <= 600px) {
+	.main-menu-sidenav.mat-drawer {
+		top: 44px !important;
+		height: calc(100vh - 44px) !important;
+	}
+
+	.main-menu-container ::ng-deep .mat-drawer-backdrop.mat-drawer-shown {
+		top: 44px !important;
+	}
+
+	.main-menu-sidenav mat-toolbar {
+		display: none !important;
+	}
+}
+
 .nav-bar {
 	position: sticky;
 	top: 0;
@@ -218,8 +246,6 @@
 		display: flex;
 		flex-direction: column;
 		align-items: flex-start;
-		border-top: var(--mat-table-row-item-outline-width, 1px) solid
-			var(--mat-table-row-item-outline-color, rgba(0, 0, 0, 0.12));
 		border-bottom: var(--mat-table-row-item-outline-width, 1px) solid
 			var(--mat-table-row-item-outline-color, rgba(0, 0, 0, 0.12));
 		margin-left: 8px;
@@ -243,7 +269,7 @@
 	}
 
 	.connection-navigation__upgrade-button {
-		margin-top: 8px;
+		margin-top: -12px;
 		margin-left: 8px;
 		width: calc(100% - 16px);
 	}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -5,7 +5,7 @@
         class="main-menu-sidenav"
         >
         <mat-toolbar>Rocketadmin</mat-toolbar>
-        <mat-nav-list *ngIf="userLoggedIn === true">
+        <mat-nav-list *ngIf="userLoggedIn === true" (click)="drawer.close()">
             <a *ngIf="!connectionID" mat-list-item routerLink="/connections-list"
                 routerLinkActive="nav-bar__button_active"
                 aria-label="List of connections">
@@ -66,7 +66,8 @@
             </mat-list-item>
         </mat-nav-list>
         <a mat-flat-button color="accent" *ngIf="isSaas && currentUser && currentUser.role === 'ADMIN'" class="connection-navigation__upgrade-button" routerLink="/upgrade"
-            routerLinkActive="nav-bar__button_active">
+            routerLinkActive="nav-bar__button_active"
+            (click)="drawer.close()">
             Upgrade
         </a>
     </mat-sidenav>

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -6,7 +6,7 @@
         >
         <mat-toolbar>Rocketadmin</mat-toolbar>
         <mat-nav-list *ngIf="userLoggedIn === true">
-            <a mat-list-item routerLink="/connections-list"
+            <a *ngIf="!connectionID" mat-list-item routerLink="/connections-list"
                 routerLinkActive="nav-bar__button_active"
                 aria-label="List of connections">
                 <mat-icon matListItemIcon class="connection-navigation__icon">
@@ -21,7 +21,7 @@
                     {{navigationTabs[tab].caption}}
                 </a>
             </mat-nav-list>
-            <a mat-list-item routerLink="/user-settings" class="connection-navigation__item_user" data-testid="account-link-account-menu">
+            <a mat-list-item routerLink="/user-settings" class="connection-navigation__item_user account-section-item" data-testid="account-link-account-menu">
                 <mat-icon matListItemIcon class="connection-navigation__icon connection-navigation__icon_account"
                     matBadge="1" [matBadgeHidden]="currentUser.isActive"
                     matBadgeColor="accent" matBadgeSize="small">
@@ -30,29 +30,37 @@
                 <div matListItemTitle>Account</div>
                 <div matListItemLine>{{currentUser.email}}</div>
             </a>
-            <a mat-list-item routerLink="/company" data-testid="company-link-account-menu">
+            <a mat-list-item routerLink="/company" class="account-section-item" data-testid="company-link-account-menu">
                 <mat-icon matListItemIcon class="connection-navigation__icon">
                     apartment
                 </mat-icon>
                 <div matListItemTitle>Company</div>
             </a>
-            <a mat-list-item routerLink="/secrets" data-testid="secrets-link-account-menu">
+            <a mat-list-item routerLink="/hosted-databases"
+                routerLinkActive="nav-bar__button_active"
+                aria-label="Hosted databases">
+                <mat-icon matListItemIcon fontSet="material-symbols-outlined" class="connection-navigation__icon">
+                    database
+                </mat-icon>
+                <div matListItemTitle>Hosted databases</div>
+            </a>
+            <a mat-list-item routerLink="/secrets" class="account-section-item" data-testid="secrets-link-account-menu">
                 <mat-icon matListItemIcon class="connection-navigation__icon">
                     key
                 </mat-icon>
                 <div matListItemTitle>Secrets</div>
             </a>
-            <a mat-list-item *ngIf="isSaas" routerLink="/zapier" data-testid="zapier-link-account-menu">
+            <a mat-list-item *ngIf="isSaas" routerLink="/zapier" class="account-section-item" data-testid="zapier-link-account-menu">
                 <mat-icon matListItemIcon class="connection-navigation__icon">
                     electric_bolt
                 </mat-icon>
                 <div matListItemTitle>Zapier</div>
             </a>
-            <a mat-list-item href="https://docs.rocketadmin.com/" target="_blank">
+            <a mat-list-item class="account-section-item" href="https://docs.rocketadmin.com/" target="_blank">
                 <mat-icon matListItemIcon class="connection-navigation__icon" fontSet="material-symbols-outlined">help</mat-icon>
                 <div matListItemTitle>Help center</div>
             </a>
-            <mat-list-item (click)="logOut()" data-testid="logout-button-account-menu">
+            <mat-list-item class="account-section-item" (click)="logOut()" data-testid="logout-button-account-menu">
                 <mat-icon matListItemIcon class="connection-navigation__icon">logout</mat-icon>
                 <div matListItemTitle>Log out</div>
             </mat-list-item>
@@ -88,7 +96,7 @@
                             class="logo__image">
                         <ng-template #defaultRocketLogo>
                             <picture>
-                                <source media="(max-width: 600px)" srcset="../assets/rocketadmin_logo_white-short.svg">
+                                <source *ngIf="connectionID" media="(max-width: 600px)" srcset="../assets/rocketadmin_logo_white-short.svg">
                                 <img src="../assets/rocketadmin_logo_white.svg" alt="Rocketadmin logo" class="logo__image">
                             </picture>
                         </ng-template>
@@ -124,6 +132,11 @@
                             routerLink="/dashboard/{{connection.connection.id}}"
                             [ngClass]="{'connection_active': connectionID === connection.connection.id}">
                             {{connection.displayTitle}}
+                        </a>
+                        <mat-divider></mat-divider>
+                        <a mat-menu-item routerLink="/hosted-databases">
+                            <mat-icon class="nav-menu__list-link-icon" fontSet="material-symbols-outlined">database</mat-icon>
+                            <span>Hosted databases</span>
                         </a>
                     </ng-template>
                 </mat-menu>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { MatBadgeModule } from '@angular/material/badge';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatMenuModule } from '@angular/material/menu';
@@ -50,6 +51,7 @@ amplitude.getInstance().init('9afd282be91f94da735c11418d5ff4f5');
 		MatButtonModule,
 		MatBadgeModule,
 		MatMenuModule,
+		MatDividerModule,
 		MatTooltipModule,
 		Angulartics2OnModule,
 		FeatureNotificationComponent,

--- a/frontend/src/app/components/audit/audit.component.css
+++ b/frontend/src/app/components/audit/audit.component.css
@@ -20,6 +20,21 @@ header {
 	margin: 0;
 }
 
+.title-block {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.title-block h1 {
+	margin: 0;
+	line-height: 1;
+}
+
+.back-button {
+	display: none !important;
+}
+
 .filters {
 	display: flex;
 	/* grid-template-columns: 1fr 1fr; */
@@ -213,5 +228,449 @@ td.mat-cell {
 @media (prefers-color-scheme: dark) {
 	.date-time {
 		color: rgba(255, 255, 255, 0.6);
+	}
+}
+
+@media (width <= 600px) {
+	.wrapper {
+		width: 100%;
+		max-width: 100%;
+		min-width: 0;
+		padding: 0 16px;
+		box-sizing: border-box;
+		overflow-x: clip;
+		overflow-y: visible;
+	}
+
+	header {
+		flex-direction: column;
+		align-items: stretch;
+		gap: 12px;
+		margin: 16px 0 12px;
+	}
+
+	.back-button {
+		display: inline-flex !important;
+		align-items: center;
+		justify-content: center;
+		margin-left: -12px;
+	}
+
+	.title-block {
+		gap: 0;
+		align-items: center;
+	}
+
+	.title-block h1 {
+		font-size: 22px;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	.filters {
+		flex-direction: row;
+		gap: 8px;
+		width: 100%;
+		max-width: 100%;
+		min-width: 0;
+	}
+
+	.filters mat-form-field {
+		flex: 1 1 0;
+		min-width: 0;
+		max-width: 100%;
+		width: auto;
+	}
+
+	.filters mat-form-field ::ng-deep .mat-mdc-text-field-wrapper,
+	.filters mat-form-field ::ng-deep .mat-mdc-form-field-flex {
+		min-width: 0 !important;
+		width: 100% !important;
+	}
+
+	.filters mat-form-field ::ng-deep .mat-mdc-form-field-infix {
+		min-width: 0 !important;
+		flex: 1 1 auto !important;
+		width: auto !important;
+	}
+
+	.filters mat-form-field ::ng-deep .mat-mdc-select {
+		width: 100%;
+	}
+
+	.filters mat-form-field ::ng-deep .mat-mdc-select-arrow-wrapper {
+		padding-left: 4px;
+	}
+
+	.audit-banner {
+		margin: 0 -16px 12px;
+		width: calc(100% + 32px);
+	}
+
+	.table-wrapper {
+		width: 100%;
+		max-width: 100%;
+		min-width: 0;
+		background: transparent !important;
+		box-shadow: none !important;
+		box-sizing: border-box;
+	}
+
+	.table-wrapper table.mat-mdc-table,
+	.table-wrapper table.mat-mdc-table thead,
+	.table-wrapper table.mat-mdc-table tbody,
+	.table-wrapper table.mat-mdc-table tr {
+		display: block;
+		width: 100%;
+	}
+
+	.table-wrapper table.mat-mdc-table thead,
+	.table-wrapper table.mat-mdc-table tr.mat-mdc-header-row,
+	.table-wrapper table.mat-mdc-table th.mat-mdc-header-cell {
+		display: none !important;
+	}
+
+	.table-wrapper table.mat-mdc-table tbody {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.table-wrapper tr.mat-mdc-row {
+		background: var(--mat-table-background-color, #fff);
+		border-radius: 12px;
+		padding: 10px 14px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 4px rgba(0, 0, 0, 0.04);
+		display: grid !important;
+		grid-template-columns: auto 1fr;
+		grid-column-gap: 12px;
+		grid-row-gap: 4px;
+		height: auto !important;
+		width: calc(100vw - 32px) !important;
+		min-width: 0 !important;
+		max-width: calc(100vw - 32px) !important;
+		box-sizing: border-box;
+		margin: 0 !important;
+	}
+
+	.table-wrapper table.mat-mdc-table {
+		min-width: 0 !important;
+		max-width: 100% !important;
+		width: 100% !important;
+		background: transparent !important;
+	}
+
+	.table-wrapper table.mat-mdc-table tbody {
+		width: 100% !important;
+	}
+
+	.table-wrapper td.mat-mdc-cell {
+		display: block;
+		border: 0 !important;
+		padding: 0 !important;
+		font-size: 13px;
+	}
+
+	.table-wrapper td.mat-mdc-cell .table-cell-content {
+		padding: 0;
+	}
+
+	/* columns order: User(1) Table(2) Action(3) Status(4) Date(5) Changes(6)
+	   Card layout:
+	   row 1: User (name + email) full width
+	   row 2: Action + Table (inline)
+	   row 3: Status
+	   row 4: Date + Details */
+	.table-wrapper td.mat-mdc-cell:nth-of-type(1) {
+		grid-column: 1 / -1;
+		grid-row: 1;
+	}
+
+	.table-wrapper td.mat-mdc-cell:nth-of-type(3) {
+		grid-column: 1 / 2;
+		grid-row: 2;
+		font-weight: 500;
+	}
+
+	.table-wrapper td.mat-mdc-cell:nth-of-type(2) {
+		grid-column: 2 / 3;
+		grid-row: 2;
+		font-weight: 600;
+		font-size: 14px;
+		justify-self: start;
+	}
+
+	.table-wrapper td.mat-mdc-cell:nth-of-type(4) {
+		grid-column: 1 / -1;
+		grid-row: 3;
+	}
+
+	.table-wrapper td.mat-mdc-cell:nth-of-type(5) {
+		grid-column: 1 / 2;
+		grid-row: 4;
+		opacity: 0.75;
+		font-size: 12px;
+	}
+
+	.table-wrapper td.mat-mdc-cell:nth-of-type(6) {
+		grid-column: 2 / 3;
+		grid-row: 4;
+		justify-self: end;
+	}
+
+	.status-badge {
+		padding: 2px 8px;
+		font-size: 12px;
+	}
+
+	.mat-h1 {
+		font-size: 22px;
+	}
+
+	.table-wrapper mat-paginator ::ng-deep .mat-mdc-paginator-container {
+		flex-wrap: nowrap !important;
+		justify-content: space-between !important;
+		padding: 0 8px !important;
+		min-height: 48px;
+	}
+
+	.table-wrapper mat-paginator ::ng-deep .mat-mdc-paginator-page-size {
+		margin: 0 !important;
+		margin-right: auto !important;
+	}
+
+	.table-wrapper mat-paginator ::ng-deep .mat-mdc-paginator-range-label {
+		margin: 0 4px !important;
+	}
+
+	.table-wrapper mat-paginator {
+		margin-top: 8px;
+		background: transparent !important;
+	}
+}
+
+@media (prefers-color-scheme: dark) and (width <= 600px) {
+	.table-wrapper tr.mat-mdc-row {
+		background: var(--surface-dark-color);
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 4px rgba(0, 0, 0, 0.2);
+	}
+}
+
+@media (width <= 600px) {
+	.audit-feed {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		width: 100%;
+		max-width: 100%;
+		min-width: 0;
+		padding-bottom: 16px;
+	}
+
+	.audit-feed.hidden {
+		display: none;
+	}
+
+	.audit-feed__date-header {
+		position: sticky;
+		top: 44px;
+		z-index: 2;
+		background: var(--mat-sidenav-content-background-color, #fff);
+		padding: 8px 0 4px;
+		font-size: 12px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: rgba(0, 0, 0, 0.54);
+	}
+
+	.audit-card {
+		display: flex;
+		align-items: flex-start;
+		gap: 12px;
+		background: var(--mat-table-background-color, #fff);
+		border-radius: 12px;
+		padding: 10px 14px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 4px rgba(0, 0, 0, 0.04);
+		cursor: pointer;
+		transition: opacity 200ms ease;
+	}
+
+	.audit-card_fade {
+		opacity: 0.6;
+	}
+
+	.audit-card__avatar {
+		flex: 0 0 36px;
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		background: var(--color-accentedPalette-100);
+		color: var(--color-accentedPalette-700);
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 13px;
+		font-weight: 600;
+	}
+
+	.audit-card__body {
+		flex: 1 1 auto;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.audit-card__row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.audit-card__row_top {
+		justify-content: space-between;
+	}
+
+	.audit-card__user {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-weight: 600;
+		font-size: 14px;
+	}
+
+	.audit-card__user-email {
+		font-weight: 400;
+		color: rgba(0, 0, 0, 0.72);
+	}
+
+	.audit-card__time {
+		flex: 0 0 auto;
+		font-size: 12px;
+		color: rgba(0, 0, 0, 0.54);
+	}
+
+	.audit-card__row_middle {
+		font-size: 13px;
+	}
+
+	.audit-card__action-icon {
+		font-size: 16px;
+		width: 16px;
+		height: 16px;
+	}
+
+	.audit-card__action {
+		font-weight: 500;
+	}
+
+	.audit-card__sep {
+		color: rgba(0, 0, 0, 0.3);
+	}
+
+	.audit-card__table {
+		font-family: "IBM Plex Mono", monospace;
+		font-size: 12px;
+		color: rgba(0, 0, 0, 0.72);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.audit-card__row_bottom {
+		justify-content: space-between;
+		margin-top: 2px;
+	}
+
+	.audit-card__details-link {
+		color: var(--color-accentedPalette-500);
+		font-size: 13px;
+		font-weight: 500;
+	}
+
+	.audit-feed__paginator {
+		margin-top: 12px;
+		background: transparent !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-outer-container,
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-container {
+		justify-content: space-between !important;
+		flex-wrap: nowrap !important;
+		min-height: 48px;
+		padding: 0 !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-page-size {
+		margin: 0 !important;
+		padding: 0 !important;
+		margin-right: auto !important;
+		flex: 0 0 auto;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-page-size-label {
+		margin: 0 4px 0 0 !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-page-size-select {
+		margin: 0 8px 0 0 !important;
+		width: auto !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-form-field-infix {
+		width: auto !important;
+		min-width: 36px !important;
+		padding-right: 4px !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-select {
+		width: auto !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-select-arrow-wrapper {
+		padding-left: 6px !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-text-field-wrapper {
+		padding: 0 10px !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-range-actions {
+		flex: 0 0 auto;
+		margin: 0 !important;
+	}
+
+	.audit-feed__paginator ::ng-deep .mat-mdc-paginator-range-label {
+		margin: 0 4px !important;
+	}
+}
+
+@media (prefers-color-scheme: dark) and (width <= 600px) {
+	.audit-feed__date-header {
+		background: var(--surface-dark-color);
+		color: rgba(255, 255, 255, 0.6);
+	}
+
+	.audit-card {
+		background: var(--surface-dark-color);
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 4px rgba(0, 0, 0, 0.2);
+	}
+
+	.audit-card__user-email {
+		color: rgba(255, 255, 255, 0.7);
+	}
+
+	.audit-card__time {
+		color: rgba(255, 255, 255, 0.54);
+	}
+
+	.audit-card__sep {
+		color: rgba(255, 255, 255, 0.3);
+	}
+
+	.audit-card__table {
+		color: rgba(255, 255, 255, 0.72);
 	}
 }

--- a/frontend/src/app/components/audit/audit.component.html
+++ b/frontend/src/app/components/audit/audit.component.html
@@ -1,6 +1,11 @@
 <div class="wrapper">
     <header>
-        <h1>Audit</h1>
+        <div class="title-block">
+            <a mat-icon-button class="back-button" routerLink="/dashboard/{{connectionID}}" aria-label="Back to dashboard">
+                <mat-icon>arrow_back</mat-icon>
+            </a>
+            <h1>Audit</h1>
+        </div>
         <div class="filters">
             <mat-form-field *ngIf="tablesList && !isServerError && !noTablesError" appearance="outline">
                 <mat-label>Tables</mat-label>
@@ -67,7 +72,49 @@
         <app-placeholder-table-data></app-placeholder-table-data>
     </div>
 
-    <div *ngIf="!noTablesError && !isServerError"
+    <div *ngIf="!noTablesError && !isServerError && isMobileView"
+        class="audit-feed"
+        [ngClass]="{hidden: dataSource.loading$ | async}">
+        <ng-container *ngFor="let group of mobileGroupedLogs; trackBy: trackByDate">
+            <div class="audit-feed__date-header">{{ group.date }}</div>
+            <div *ngFor="let entry of group.entries; let last = last"
+                class="audit-card"
+                [class.audit-card_fade]="last && mobileGroupedLogs.length > 0"
+                (click)="openInfoLogDialog(entry); posthog.capture('Audit: view changes is clicked')">
+                <div class="audit-card__avatar">{{ getInitials(entry.UserEmail) }}</div>
+                <div class="audit-card__body">
+                    <div class="audit-card__row audit-card__row_top">
+                        <span class="audit-card__user">
+                            <span class="audit-card__user-name" *ngIf="getUserName(entry.UserEmail)">{{ getUserName(entry.UserEmail) }}</span>
+                            <span class="audit-card__user-email" *ngIf="!getUserName(entry.UserEmail)">{{ entry.UserEmail }}</span>
+                        </span>
+                        <span class="audit-card__time">{{ entry.TimeOnly }}</span>
+                    </div>
+                    <div class="audit-card__row audit-card__row_middle">
+                        <mat-icon *ngIf="entry.ActionIcon" class="audit-card__action-icon" [ngClass]="'action-icon--' + entry.ActionIcon">{{ entry.ActionIcon }}</mat-icon>
+                        <span class="audit-card__action">{{ entry.Action || '—' }}</span>
+                        <span class="audit-card__sep">·</span>
+                        <span class="audit-card__table">{{ entry.Table }}</span>
+                    </div>
+                    <div class="audit-card__row audit-card__row_bottom">
+                        <span class="status-badge"
+                            [ngClass]="{'status-succeed': entry.Status === 'successfully'}">
+                            {{ entry.Status === 'successfully' ? 'Success' : (entry.Status || '—') }}
+                        </span>
+                        <span class="audit-card__details-link">Details &rsaquo;</span>
+                    </div>
+                </div>
+            </div>
+        </ng-container>
+        <mat-paginator
+            class="audit-feed__paginator"
+            [pageSize]="30"
+            [pageSizeOptions]="[10, 30, 100, 300]"
+            [showFirstLastButtons]="true">
+        </mat-paginator>
+    </div>
+
+    <div *ngIf="!noTablesError && !isServerError && !isMobileView"
         class="mat-elevation-z4 table-wrapper"
         [ngClass]="{hidden: dataSource.loading$ | async}">
         <table mat-table [dataSource]="dataSource" NgMatTableQueryReflector>

--- a/frontend/src/app/components/audit/audit.component.ts
+++ b/frontend/src/app/components/audit/audit.component.ts
@@ -5,7 +5,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
-import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatPaginator, MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTableModule } from '@angular/material/table';
 import { Title } from '@angular/platform-browser';
@@ -69,6 +69,12 @@ export class AuditComponent implements OnInit {
 
 	public dataSource: AuditDataSource = null;
 
+	public mobileGroupedLogs: { date: string; entries: any[] }[] = [];
+
+	get isMobileView(): boolean {
+		return typeof window !== 'undefined' && window.innerWidth <= 600;
+	}
+
 	@ViewChild(MatPaginator) paginator: MatPaginator;
 
 	constructor(
@@ -78,7 +84,11 @@ export class AuditComponent implements OnInit {
 		private _companyService: CompanyService,
 		public dialog: MatDialog,
 		private title: Title,
-	) {}
+		private paginatorIntl: MatPaginatorIntl,
+	) {
+		this.paginatorIntl.itemsPerPageLabel = 'Per page:';
+		this.paginatorIntl.changes.next();
+	}
 
 	ngAfterViewInit() {
 		this.dataSource.paginator = this.paginator;
@@ -100,6 +110,9 @@ export class AuditComponent implements OnInit {
 		this.columns = ['User', 'Table', 'Action', 'Status', 'Date', 'Changes'];
 		this.dataColumns = ['User', 'Table', 'Action', 'Status', 'Date'];
 		this.dataSource = new AuditDataSource(this._connections);
+		this.dataSource.connect(null as any).subscribe((rows) => {
+			this.mobileGroupedLogs = this.groupByDate(rows);
+		});
 		this.loadLogsPage();
 
 		this._tables.fetchTables(this.connectionID).subscribe(
@@ -148,5 +161,37 @@ export class AuditComponent implements OnInit {
 		if (!this.usersList) return null;
 		const user = this.usersList.find((u) => u.email === email);
 		return user?.name || null;
+	}
+
+	getInitials(email: string): string {
+		if (!email) return '?';
+		const name = this.getUserName(email);
+		if (name) {
+			const parts = name.trim().split(/\s+/);
+			return parts
+				.slice(0, 2)
+				.map((p) => p[0]?.toUpperCase() ?? '')
+				.join('');
+		}
+		const local = email.split('@')[0];
+		const parts = local.split(/[._-]/);
+		return parts
+			.slice(0, 2)
+			.map((p) => p[0]?.toUpperCase() ?? '')
+			.join('');
+	}
+
+	trackByDate(_index: number, group: { date: string }): string {
+		return group.date;
+	}
+
+	private groupByDate(rows: any[]): { date: string; entries: any[] }[] {
+		const groups = new Map<string, any[]>();
+		for (const row of rows) {
+			const date = row.DateOnly;
+			if (!groups.has(date)) groups.set(date, []);
+			groups.get(date)!.push(row);
+		}
+		return Array.from(groups, ([date, entries]) => ({ date, entries }));
 	}
 }

--- a/frontend/src/app/components/auto-configure/auto-configure.component.css
+++ b/frontend/src/app/components/auto-configure/auto-configure.component.css
@@ -64,6 +64,16 @@
 	}
 }
 
+.card__head-detail {
+	width: 100%;
+	min-height: 64px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+}
+
 .card__subtitle {
 	margin: 0;
 	font-size: 14px;
@@ -191,33 +201,193 @@
 	to { transform: rotate(-360deg); }
 }
 
-/* ── Indeterminate progress bar ── */
+/* ── Success checkmark (replaces spinner on complete) ── */
 
-.progress-bar {
+.success-mark {
+	width: 72px;
+	height: 72px;
+	margin-bottom: 8px;
+}
+
+.success-mark svg {
 	width: 100%;
-	max-width: 320px;
-	height: 4px;
-	border-radius: 2px;
-	background: var(--color-primaryPalette-200);
-	overflow: hidden;
+	height: 100%;
+	overflow: visible;
+}
+
+.success-mark__circle {
+	fill: none;
+	stroke: var(--color-successPalette-500);
+	stroke-width: 2;
+	stroke-linecap: round;
+	stroke-dasharray: 158;
+	stroke-dashoffset: 158;
+	animation: success-circle 500ms ease-out forwards;
+	transform-origin: 50% 50%;
+}
+
+.success-mark__check {
+	fill: none;
+	stroke: var(--color-successPalette-500);
+	stroke-width: 3.5;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	stroke-dasharray: 36;
+	stroke-dashoffset: 36;
+	animation: success-check 350ms 400ms ease-out forwards;
+}
+
+@keyframes success-circle {
+	to { stroke-dashoffset: 0; }
+}
+
+@keyframes success-check {
+	to { stroke-dashoffset: 0; }
+}
+
+/* ── Summary chips (shown on complete) ── */
+
+.summary-chips {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	gap: 8px;
 	margin-top: 4px;
 }
 
+.summary-chip {
+	display: inline-flex;
+	align-items: baseline;
+	gap: 4px;
+	padding: 4px 10px;
+	border-radius: 999px;
+	background: var(--color-successPalette-50);
+	color: var(--color-successPalette-700);
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.4;
+	white-space: nowrap;
+	animation: chip-enter 280ms ease-out;
+}
+
+.summary-chip strong {
+	font-size: 13px;
+	font-weight: 700;
+}
+
 @media (prefers-color-scheme: dark) {
-	.progress-bar {
-		background: var(--color-primaryPalette-800);
+	.summary-chip {
+		background: var(--color-successPalette-900);
+		color: var(--color-successPalette-100);
 	}
 }
 
-.progress-bar__fill {
-	width: 40%;
-	height: 100%;
-	border-radius: 2px;
-	background: var(--color-accentedPalette-500);
-	animation: indeterminate 1.5s ease-in-out infinite;
+@keyframes chip-enter {
+	from { transform: scale(0.85); opacity: 0; }
+	to { transform: scale(1); opacity: 1; }
 }
 
-@keyframes indeterminate {
-	0% { transform: translateX(-100%); }
-	100% { transform: translateX(350%); }
+/* ── Live status log ── */
+
+.status-log {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	width: 100%;
+	max-width: 360px;
+	min-height: 132px;
+	display: flex;
+	flex-direction: column;
+	justify-content: flex-start;
+	gap: 8px;
+}
+
+.status-log__item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	font-size: 13px;
+	color: var(--color-primaryPalette-400);
+	text-align: left;
+	line-height: 1.35;
+	animation: status-log-enter 240ms ease-out;
+}
+
+.status-log__item_done {
+	color: var(--color-primaryPalette-200);
+	font-size: 12px;
+}
+
+.status-log__item_current {
+	color: var(--color-primaryPalette-800);
+	font-weight: 500;
+}
+
+@media (prefers-color-scheme: dark) {
+	.status-log__item_done {
+		color: var(--color-primaryPalette-500);
+	}
+	.status-log__item_current {
+		color: var(--color-primaryPalette-50);
+	}
+}
+
+.status-log__icon {
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.status-log__check {
+	color: var(--color-primaryPalette-200);
+	font-size: 13px;
+	font-weight: 700;
+	line-height: 1;
+}
+
+@media (prefers-color-scheme: dark) {
+	.status-log__check {
+		color: var(--color-primaryPalette-500);
+	}
+}
+
+.status-log__spinner {
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	border: 2px solid var(--color-accentedPalette-200);
+	border-top-color: var(--color-accentedPalette-500);
+	animation: tiny-spin 0.8s linear infinite;
+}
+
+@keyframes tiny-spin {
+	to { transform: rotate(360deg); }
+}
+
+@keyframes status-log-enter {
+	from { transform: translateY(-6px); opacity: 0; }
+	to { transform: translateY(0); opacity: 1; }
+}
+
+.card__status {
+	margin: 0;
+	min-height: 20px;
+	font-size: 13px;
+	color: var(--color-primaryPalette-500);
+	text-align: center;
+	line-height: 1.4;
+	max-width: 360px;
+}
+
+.card__status_error {
+	color: var(--color-warnPalette-500);
+}
+
+@media (prefers-color-scheme: dark) {
+	.card__status {
+		color: var(--color-primaryPalette-200);
+	}
 }

--- a/frontend/src/app/components/auto-configure/auto-configure.component.css
+++ b/frontend/src/app/components/auto-configure/auto-configure.component.css
@@ -46,8 +46,8 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	padding: 48px 32px 36px;
-	gap: 16px;
+	padding: 40px 32px 24px;
+	gap: 10px;
 }
 
 .card__title {
@@ -170,7 +170,6 @@
 	position: relative;
 	width: 72px;
 	height: 72px;
-	margin-bottom: 8px;
 }
 
 .spinner__ring {
@@ -206,7 +205,6 @@
 .success-mark {
 	width: 72px;
 	height: 72px;
-	margin-bottom: 8px;
 }
 
 .success-mark svg {
@@ -295,11 +293,14 @@
 	padding: 0;
 	width: 100%;
 	max-width: 360px;
-	min-height: 132px;
+	height: 78px;
 	display: flex;
 	flex-direction: column;
-	justify-content: flex-start;
+	justify-content: flex-end;
 	gap: 8px;
+	overflow: hidden;
+	mask-image: linear-gradient(to bottom, transparent 0, black 28px);
+	-webkit-mask-image: linear-gradient(to bottom, transparent 0, black 28px);
 }
 
 .status-log__item {

--- a/frontend/src/app/components/auto-configure/auto-configure.component.html
+++ b/frontend/src/app/components/auto-configure/auto-configure.component.html
@@ -1,28 +1,42 @@
 <div class="page">
 	<div class="card">
 		<div class="card__body">
-			<div class="spinner">
+			<div *ngIf="!done()" class="spinner">
 				<div class="spinner__ring spinner__ring--outer"></div>
 				<div class="spinner__ring spinner__ring--inner"></div>
 			</div>
-			<h2 class="card__title">Configuring your database</h2>
-			<p class="card__subtitle">We're analyzing your structure and applying the best settings. This is running in the background.</p>
-
-			<p *ngIf="progress() as p" class="card__status">
-				<ng-container *ngIf="p.table">
-					{{ p.step || 'Configuring' }}
-					<strong>{{ p.table }}</strong>
-				</ng-container>
-				<ng-container *ngIf="!p.table && p.message">{{ p.message }}</ng-container>
-				<span *ngIf="p.current && p.total" class="card__status-counter">
-					· {{ p.current }} of {{ p.total }}
-				</span>
-			</p>
-
-			<div class="progress-bar" [class.progress-bar_determinate]="percent() !== null">
-				<div class="progress-bar__fill"
-					[style.width.%]="percent() !== null ? percent() : null"></div>
+			<div *ngIf="done()" class="success-mark" aria-label="Configuration complete">
+				<svg viewBox="0 0 52 52" xmlns="http://www.w3.org/2000/svg">
+					<circle class="success-mark__circle" cx="26" cy="26" r="25"></circle>
+					<path class="success-mark__check" d="M14 27 l8 8 l16 -18"></path>
+				</svg>
 			</div>
+			<h2 class="card__title">{{ done() ? 'Your database is ready' : 'Configuring your database' }}</h2>
+			<div class="card__head-detail">
+				<p *ngIf="!done()" class="card__subtitle">We're analyzing your structure and applying the best settings. This is running in the background.</p>
+				<div *ngIf="hasSummary()" class="summary-chips">
+					<span class="summary-chip"><strong>{{ tablesConfigured().size }}</strong> {{ tablesConfigured().size === 1 ? 'table' : 'tables' }}</span>
+					<span *ngIf="widgetsCount() > 0" class="summary-chip"><strong>{{ widgetsCount() }}</strong> {{ widgetsCount() === 1 ? 'widget' : 'widgets' }}</span>
+					<span *ngIf="settingsCount() > 0" class="summary-chip"><strong>{{ settingsCount() }}</strong> {{ settingsCount() === 1 ? 'setting' : 'settings' }}</span>
+				</div>
+				<p *ngIf="done() && !hasSummary()" class="card__subtitle">All set — opening your dashboard…</p>
+			</div>
+
+			<ul class="status-log" *ngIf="!errorText(); else errorBlock">
+				<li *ngFor="let m of messages(); let last = last; trackBy: trackByIndex"
+					class="status-log__item"
+					[class.status-log__item_current]="last"
+					[class.status-log__item_done]="!last">
+					<span class="status-log__icon" aria-hidden="true">
+						<span *ngIf="!last" class="status-log__check">&#10003;</span>
+						<span *ngIf="last" class="status-log__spinner"></span>
+					</span>
+					<span class="status-log__text">{{ m }}</span>
+				</li>
+			</ul>
+			<ng-template #errorBlock>
+				<p class="card__status card__status_error">{{ errorText() }}</p>
+			</ng-template>
 		</div>
 		<div class="card__footer">
 			<p class="card__footer-text">You can start working — setup will continue in the background.</p>

--- a/frontend/src/app/components/auto-configure/auto-configure.component.html
+++ b/frontend/src/app/components/auto-configure/auto-configure.component.html
@@ -7,8 +7,21 @@
 			</div>
 			<h2 class="card__title">Configuring your database</h2>
 			<p class="card__subtitle">We're analyzing your structure and applying the best settings. This is running in the background.</p>
-			<div class="progress-bar">
-				<div class="progress-bar__fill"></div>
+
+			<p *ngIf="progress() as p" class="card__status">
+				<ng-container *ngIf="p.table">
+					{{ p.step || 'Configuring' }}
+					<strong>{{ p.table }}</strong>
+				</ng-container>
+				<ng-container *ngIf="!p.table && p.message">{{ p.message }}</ng-container>
+				<span *ngIf="p.current && p.total" class="card__status-counter">
+					· {{ p.current }} of {{ p.total }}
+				</span>
+			</p>
+
+			<div class="progress-bar" [class.progress-bar_determinate]="percent() !== null">
+				<div class="progress-bar__fill"
+					[style.width.%]="percent() !== null ? percent() : null"></div>
 			</div>
 		</div>
 		<div class="card__footer">

--- a/frontend/src/app/components/auto-configure/auto-configure.component.ts
+++ b/frontend/src/app/components/auto-configure/auto-configure.component.ts
@@ -1,21 +1,32 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { Subscription } from 'rxjs';
 
-import { ConfigurationStateService } from '../../services/configuration-state.service';
+import { ConfigProgress, ConfigurationStateService } from '../../services/configuration-state.service';
 
 @Component({
 	selector: 'app-auto-configure',
 	templateUrl: './auto-configure.component.html',
 	styleUrls: ['./auto-configure.component.css'],
-	imports: [MatButtonModule, RouterModule],
+	imports: [CommonModule, MatButtonModule, RouterModule],
 })
-export class AutoConfigureComponent implements OnInit {
+export class AutoConfigureComponent implements OnInit, OnDestroy {
 	private _route = inject(ActivatedRoute);
 	private _router = inject(Router);
 	private _configState = inject(ConfigurationStateService);
 
 	protected connectionId = signal<string | null>(null);
+	protected progress = signal<ConfigProgress | null>(null);
+	private _progressSub?: Subscription;
+
+	protected percent = computed(() => {
+		const p = this.progress();
+		if (!p || !p.total || p.total <= 0) return null;
+		const pct = ((p.current ?? 0) / p.total) * 100;
+		return Math.min(100, Math.max(0, Math.round(pct)));
+	});
 
 	async ngOnInit(): Promise<void> {
 		const connectionId = this._route.snapshot.paramMap.get('connection-id');
@@ -25,7 +36,12 @@ export class AutoConfigureComponent implements OnInit {
 		}
 
 		this.connectionId.set(connectionId);
+		this._progressSub = this._configState.progress$.subscribe((p) => this.progress.set(p));
 		await this._configState.startConfiguring(connectionId);
 		this._router.navigate(['/dashboard', connectionId]);
+	}
+
+	ngOnDestroy(): void {
+		this._progressSub?.unsubscribe();
 	}
 }

--- a/frontend/src/app/components/auto-configure/auto-configure.component.ts
+++ b/frontend/src/app/components/auto-configure/auto-configure.component.ts
@@ -19,14 +19,23 @@ export class AutoConfigureComponent implements OnInit, OnDestroy {
 
 	protected connectionId = signal<string | null>(null);
 	protected progress = signal<ConfigProgress | null>(null);
+	protected messages = signal<string[]>(['Initializing…']);
+	protected tablesConfigured = signal<Set<string>>(new Set<string>());
+	protected widgetsCount = signal<number>(0);
+	protected settingsCount = signal<number>(0);
 	private _progressSub?: Subscription;
 
-	protected percent = computed(() => {
+	protected errorText = computed(() => {
 		const p = this.progress();
-		if (!p || !p.total || p.total <= 0) return null;
-		const pct = ((p.current ?? 0) / p.total) * 100;
-		return Math.min(100, Math.max(0, Math.round(pct)));
+		if (p?.type === 'error') return p.message ?? 'Something went wrong.';
+		return null;
 	});
+
+	protected done = computed(() => this.progress()?.type === 'complete');
+
+	protected hasSummary = computed(
+		() => this.done() && (this.tablesConfigured().size > 0 || this.widgetsCount() > 0 || this.settingsCount() > 0),
+	);
 
 	async ngOnInit(): Promise<void> {
 		const connectionId = this._route.snapshot.paramMap.get('connection-id');
@@ -36,12 +45,135 @@ export class AutoConfigureComponent implements OnInit, OnDestroy {
 		}
 
 		this.connectionId.set(connectionId);
-		this._progressSub = this._configState.progress$.subscribe((p) => this.progress.set(p));
+		this._progressSub = this._configState.progress$.subscribe((p) => {
+			this.progress.set(p);
+			if (p?.type === 'message' && p.text) this._countMessage(p.text);
+			const rawIncoming =
+				p?.type === 'message' && p.text
+					? p.text
+					: p?.type === 'complete'
+						? 'All done — opening your dashboard…'
+						: null;
+			if (!rawIncoming) return;
+			const incoming = this._humanize(rawIncoming);
+			if (!incoming) return;
+			const current = this.messages();
+			if (current[current.length - 1] === incoming) return;
+			this.messages.set([...current, incoming].slice(-5));
+		});
 		await this._configState.startConfiguring(connectionId);
+		// Let the user read the summary chips before navigating away.
+		await new Promise((resolve) => setTimeout(resolve, 1800));
 		this._router.navigate(['/dashboard', connectionId]);
 	}
 
 	ngOnDestroy(): void {
 		this._progressSub?.unsubscribe();
+	}
+
+	trackByIndex(index: number): number {
+		return index;
+	}
+
+	private _countMessage(text: string): void {
+		const widgetMatch = text.match(/^Added\s+\S+\s+widget for table "([^"]+)"/i);
+		if (widgetMatch) {
+			this.widgetsCount.update((n) => n + 1);
+			this._addConfiguredTable(widgetMatch[1]);
+			return;
+		}
+		const settingMatch = text.match(/^Set up settings for table "([^"]+)",\s+\S+ parameter/i);
+		if (settingMatch) {
+			this.settingsCount.update((n) => n + 1);
+			this._addConfiguredTable(settingMatch[1]);
+			return;
+		}
+		const defaultsMatch = text.match(/^Set up settings for table "([^"]+)" with default parameters/i);
+		if (defaultsMatch) {
+			this._addConfiguredTable(defaultsMatch[1]);
+		}
+	}
+
+	private _addConfiguredTable(name: string): void {
+		const current = this.tablesConfigured();
+		if (current.has(name)) return;
+		const next = new Set(current);
+		next.add(name);
+		this.tablesConfigured.set(next);
+	}
+
+	private _humanize(text: string): string {
+		if (/^Initializing|^Starting configuration|^✓ Setup complete|^All done/i.test(text)) return text;
+		if (/^Starting AI scan/i.test(text)) return 'Looking at your database…';
+		if (/^Fetching tables from database/i.test(text)) return 'Reading your tables…';
+
+		let m = text.match(/^Found (\d+) new (?:table|tables) to scan/i);
+		if (m) return `Found ${m[1]} ${m[1] === '1' ? 'table' : 'tables'} to set up`;
+		if (/^No new tables to scan/i.test(text)) return 'Everything is already set up';
+
+		m = text.match(/^Inspected structure of table "([^"]+)"/i);
+		if (m) return `Read structure of ${m[1]}`;
+
+		m = text.match(/^Generating settings with AI for (\d+)/i);
+		if (m) return `Choosing the best layout for ${m[1]} ${m[1] === '1' ? 'table' : 'tables'}…`;
+
+		m = text.match(/^AI returned settings for (\d+)/i);
+		if (m) return `Recommendations ready for ${m[1]} ${m[1] === '1' ? 'table' : 'tables'}`;
+
+		m = text.match(/^Validation failed for table "([^"]+)"/i);
+		if (m) return `Couldn't configure ${m[1]}, skipped it`;
+
+		m = text.match(/^Set up settings for table "([^"]+)", display_name parameter set to "([^"]+)"/i);
+		if (m) return `Renamed ${m[1]} → ${m[2]}`;
+
+		m = text.match(/^Set up settings for table "([^"]+)", search_fields parameter set to (.+)$/i);
+		if (m) return `Search by ${m[2]} in ${m[1]}`;
+
+		m = text.match(/^Set up settings for table "([^"]+)", readonly_fields parameter set to (.+)$/i);
+		if (m) return `Locked fields in ${m[1]}: ${m[2]}`;
+
+		m = text.match(/^Set up settings for table "([^"]+)", columns_view parameter set to (.+)$/i);
+		if (m) return `Showing ${m[2]} on ${m[1]} overview`;
+
+		m = text.match(/^Set up settings for table "([^"]+)", ordering parameter set to (ASC|DESC)/i);
+		if (m) return `${m[1]} sorted ${m[2].toLowerCase() === 'asc' ? 'ascending' : 'descending'} by default`;
+
+		m = text.match(/^Set up settings for table "([^"]+)", ordering_field parameter set to "([^"]+)"/i);
+		if (m) return `${m[1]} sorts by ${m[2]} by default`;
+
+		m = text.match(/^Set up settings for table "([^"]+)", identity_column parameter set to "([^"]+)"/i);
+		if (m) return `${m[1]} identified by ${m[2]}`;
+
+		m = text.match(/^Set up settings for table "([^"]+)" with default parameters/i);
+		if (m) return `${m[1]} is ready with default setup`;
+
+		m = text.match(/^Added (\S+) widget for table "([^"]+)" on column "([^"]+)"/i);
+		if (m) return this._widgetPhrase(m[1], m[2], m[3]);
+
+		// Generic fallback for any unmatched "Set up settings ... <param> parameter ..." line
+		m = text.match(/^Set up settings for table "([^"]+)", (\S+) parameter/i);
+		if (m) return `${m[1]}: ${m[2].replace(/_/g, ' ')} configured`;
+
+		return text;
+	}
+
+	private _widgetPhrase(kind: string, table: string, column: string): string {
+		const ref = `${table}.${column}`;
+		switch (kind.toLowerCase()) {
+			case 'phone':
+				return `${ref} formatted as phone numbers`;
+			case 'uuid':
+				return `${ref} recognized as ID`;
+			case 'country':
+				return `${ref} shows country flags`;
+			case 'url':
+				return `${ref} shown as clickable link`;
+			case 'color':
+				return `${ref} shows a color swatch`;
+			case 'string':
+				return `${ref} validates email format`;
+			default:
+				return `${kind} widget enabled for ${ref}`;
+		}
 	}
 }

--- a/frontend/src/app/components/connection-settings/connection-settings.component.css
+++ b/frontend/src/app/components/connection-settings/connection-settings.component.css
@@ -181,13 +181,13 @@
 
 @media (width <= 600px) {
 	.color-theme {
-		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		grid-gap: 8px;
-		align-items: center;
+		display: flex;
+		flex-direction: column;
+		gap: 0;
 	}
 
 	.color-item {
+		width: 100%;
 		min-width: 0;
 	}
 

--- a/frontend/src/app/components/connection-settings/connection-settings.component.css
+++ b/frontend/src/app/components/connection-settings/connection-settings.component.css
@@ -178,3 +178,33 @@
 .audit-toggle {
 	margin-top: 4px;
 }
+
+@media (width <= 600px) {
+	.color-theme {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		grid-gap: 8px;
+		align-items: center;
+	}
+
+	.color-item {
+		min-width: 0;
+	}
+
+	.color-input {
+		width: 100%;
+		min-width: 0;
+	}
+
+	.color-input ::ng-deep .mat-mdc-text-field-wrapper,
+	.color-input ::ng-deep .mat-mdc-form-field-flex,
+	.color-input ::ng-deep .mat-mdc-form-field-infix {
+		min-width: 0 !important;
+		width: auto !important;
+	}
+
+	.color-input ::ng-deep input.mat-mdc-input-element {
+		padding-left: 24px;
+		min-width: 0;
+	}
+}

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.css
@@ -75,7 +75,7 @@
 	width: calc(100vw - 65px);
 	padding-left: 0;
 	border-left: none;
-	z-index: 3;
+	z-index: 100;
 	transition:
 		left 400ms cubic-bezier(0.4, 0, 0.2, 1),
 		width 400ms cubic-bezier(0.4, 0, 0.2, 1),

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.css
@@ -73,7 +73,7 @@
 .ai-panel-sidebar-content_open.ai-panel-sidebar-content_expanded {
 	left: 65px;
 	width: calc(100vw - 65px);
-	padding-left: 175px;
+	padding-left: 0;
 	border-left: none;
 	z-index: 3;
 	transition:
@@ -99,6 +99,7 @@
 	.ai-panel-sidebar-content_open.ai-panel-sidebar-content_expanded {
 		left: 0;
 		width: 100%;
+		padding-left: 0;
 	}
 }
 
@@ -677,19 +678,8 @@
 }
 
 .ai-panel-sidebar-content_expanded .ai-panel-sidebar__header {
-	position: relative;
 	width: 100%;
-	max-width: 800px;
-	margin: 0 auto;
-	padding-left: 0;
-	padding-right: 0;
-	justify-content: flex-start;
-}
-
-.ai-panel-sidebar-content_expanded .ai-panel-sidebar__actions {
-	position: fixed;
-	right: 16px;
-	top: 64px;
+	justify-content: space-between;
 }
 
 .ai-panel-sidebar-content_expanded .ai-welcome__section {

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.html
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.html
@@ -4,14 +4,8 @@
 <div class="ai-panel-sidebar-content ai-panel-sidebar-content_open"
     [ngClass]="{'ai-panel-sidebar-content_expanded': isExpanded, 'ai-panel-sidebar-content_sidebar-collapsed': !sidebarExpanded}">
     <div class="ai-panel-sidebar__header">
-        <h2 class="mat-heading-2 ai-panel-sidebar__title">
-            <span *ngIf="isExpanded">AI insights for {{displayName}}</span>
-            <span *ngIf="!isExpanded">AI insights</span>
-        </h2>
+        <h2 class="mat-heading-2 ai-panel-sidebar__title">AI insights</h2>
         <div class="ai-panel-sidebar__actions">
-            <button type="button" mat-icon-button (click)="toggleExpand()">
-                <mat-icon>{{isExpanded ? 'close_fullscreen' : 'open_in_full'}}</mat-icon>
-            </button>
             <button type="button" mat-icon-button (click)="handleClose()">
                 <mat-icon>close</mat-icon>
             </button>

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.ts
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-ai-panel/db-table-ai-panel.component.ts
@@ -65,7 +65,7 @@ export class DbTableAiPanelComponent implements OnInit, AfterViewInit, OnDestroy
 	public activeCompletions: string[] = [];
 	public showCompletions: boolean = false;
 	public submitting: boolean = false;
-	public isExpanded: boolean = false;
+	public isExpanded: boolean = true;
 	public textareaRows: number = 4;
 	public currentLoadingStep: string = '';
 
@@ -97,8 +97,8 @@ export class DbTableAiPanelComponent implements OnInit, AfterViewInit, OnDestroy
 			this.isAIpanelOpened = isAIpanelOpened;
 		});
 
-		this._tableState.aiPanelExpandedCast.subscribe((isExpanded) => {
-			this.isExpanded = isExpanded;
+		this._tableState.aiPanelExpandedCast.subscribe(() => {
+			this.isExpanded = true;
 		});
 
 		this.adjustTextareaRows();

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-row-view/db-table-row-view.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-row-view/db-table-row-view.component.css
@@ -125,6 +125,7 @@
 }
 
 .row-preview-sidebar__field {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
@@ -132,13 +133,19 @@
 	padding: 12px 20px;
 }
 
-.row-preview-sidebar__field:not(:last-child) {
-	border-bottom: solid 1px rgba(0, 0, 0, 0.12);
+.row-preview-sidebar__field:not(:last-child)::after {
+	content: '';
+	position: absolute;
+	left: 20px;
+	right: 20px;
+	bottom: 0;
+	height: 1px;
+	background: rgba(0, 0, 0, 0.12);
 }
 
 @media (prefers-color-scheme: dark) {
-	.row-preview-sidebar__field:not(:last-child) {
-		border-bottom: solid 1px rgba(255, 255, 255, 0.04);
+	.row-preview-sidebar__field:not(:last-child)::after {
+		background: rgba(255, 255, 255, 0.04);
 	}
 }
 

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.css
@@ -613,7 +613,11 @@
 	display: contents;
 }
 
-.search-row__filter {
+.search-row__filter,
+.search-row__add-quick-filter,
+.search-row__create-fast-filter,
+.search-row__divider,
+.search-row__quick-chips-slot {
 	display: none;
 }
 
@@ -675,6 +679,161 @@
 		font-size: 18px;
 		width: 18px;
 		height: 18px;
+	}
+
+	.search-row__add-quick-filter {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: 0 0 auto;
+		width: 32px;
+		height: 32px;
+		min-width: 32px;
+		min-height: 32px;
+		padding: 0 !important;
+		--mdc-icon-button-state-layer-size: 32px;
+		--mat-icon-button-state-layer-size: 32px;
+		--mdc-icon-button-icon-size: 20px;
+	}
+
+	.search-row__add-quick-filter .mat-icon {
+		font-size: 20px;
+		width: 20px;
+		height: 20px;
+		margin: 0;
+	}
+
+	.search-row__add-quick-filter ::ng-deep .mat-mdc-button-touch-target {
+		width: 32px;
+		height: 32px;
+	}
+
+	.search-row__add-quick-filter ::ng-deep .mat-mdc-button-persistent-ripple,
+	.search-row__add-quick-filter ::ng-deep .mat-mdc-focus-indicator {
+		inset: 0;
+		border-radius: 50%;
+	}
+
+	.search-row__create-fast-filter {
+		display: inline-flex;
+		flex: 0 0 auto;
+		height: 32px;
+		line-height: 32px;
+		padding: 0 12px;
+		border-radius: 999px;
+		font-size: 13px;
+		gap: 4px;
+	}
+
+	.search-row__create-fast-filter .mat-icon {
+		font-size: 18px;
+		width: 18px;
+		height: 18px;
+	}
+
+	.db-table-header,
+	.db-table-actions,
+	.search-row {
+		min-width: 0;
+	}
+
+	.search-row__buttons {
+		min-width: 0;
+		max-width: 100%;
+		overflow: hidden;
+	}
+
+	.search-row__quick-chips-slot {
+		position: relative;
+		display: block;
+		flex: 1 1 0;
+		min-width: 0;
+		width: 0;
+		max-width: 100%;
+		height: 32px;
+		overflow: hidden;
+	}
+
+	.search-row__quick-chips {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		overflow-x: auto;
+		overflow-y: hidden;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+	}
+
+	.search-row__quick-chips::-webkit-scrollbar {
+		display: none;
+	}
+
+	.search-row__quick-chip {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: center;
+		border: 1px solid var(--mdc-outlined-button-outline-color, rgba(0, 0, 0, 0.12));
+		background: transparent;
+		color: var(--color-primaryPalette-700);
+		font-size: 13px;
+		font-weight: 500;
+		padding: 0 8px 0 12px;
+		height: 32px;
+		line-height: 30px;
+		border-radius: 999px;
+		white-space: nowrap;
+		cursor: pointer;
+	}
+
+	.search-row__quick-chip_active {
+		background: var(--color-accentedPalette-500);
+		border-color: var(--color-accentedPalette-500);
+		color: var(--color-accentedPalette-500-contrast);
+	}
+
+	.search-row__quick-chip-menu {
+		background: transparent;
+		border: 0;
+		padding: 0;
+		margin-left: 4px;
+		width: 20px;
+		height: 20px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		cursor: pointer;
+		color: inherit;
+		opacity: 0.7;
+	}
+
+	.search-row__quick-chip-menu .mat-icon {
+		font-size: 16px;
+		width: 16px;
+		height: 16px;
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.search-row__quick-chip {
+			border-color: var(--mdc-outlined-button-outline-color, rgba(255, 255, 255, 0.24));
+			color: var(--color-primaryPalette-100);
+		}
+	}
+
+	.search-row__divider {
+		display: inline-block;
+		flex: 0 0 auto;
+		width: 1px;
+		align-self: stretch;
+		margin: 4px 4px;
+		background: var(--color-primaryPalette-200);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		.search-row__divider {
+			background: var(--color-primaryPalette-700);
+		}
 	}
 
 	.saved-filters-row__columns {
@@ -762,25 +921,69 @@
 @media (width <= 600px) {
 	.saved-filters-row {
 		display: flex;
+		flex-wrap: wrap;
 		align-items: flex-start;
-		gap: 8px;
+		justify-content: flex-end;
+		gap: 4px 8px;
+		width: 100%;
+		max-width: 100%;
+		min-width: 0;
+		overflow: hidden;
 	}
 
 	.saved-filters-row > app-saved-filters-panel {
 		flex: 1 1 auto;
 		min-width: 0;
+		max-width: 100%;
 		display: block;
+		overflow: hidden;
+	}
+
+	.saved-filters-row:has(.filters-container) > app-saved-filters-panel {
+		flex: 0 0 100%;
+		order: 1;
+	}
+
+	.saved-filters-row:has(.filters-container) > .saved-filters-row__columns,
+	.saved-filters-row:has(.filters-container) > .mobile-sort-button {
+		order: 2;
 	}
 
 	.mobile-sort-button {
 		display: inline-flex !important;
 		align-items: center;
-		gap: 4px;
+		gap: 2px;
 		flex: 0 0 auto;
 		min-height: 36px;
 		padding: 0 10px;
 		font-size: 13px;
 		font-weight: 500;
+		--mdc-text-button-label-text-color: rgba(0, 0, 0, 0.87);
+		--mat-mdc-button-persistent-ripple-color: rgba(0, 0, 0, 0.87);
+		color: rgba(0, 0, 0, 0.87) !important;
+	}
+
+	.mobile-sort-button .mat-icon,
+	.mobile-sort-button .mat-mdc-button-touch-target ~ * {
+		color: inherit !important;
+	}
+
+	.mobile-sort-button ::ng-deep .mat-mdc-button > .mat-icon,
+	.mobile-sort-button ::ng-deep .mdc-button__label > .mat-icon,
+	.mobile-sort-button .mat-icon {
+		margin-right: 2px !important;
+		margin-left: 0 !important;
+	}
+
+	.mobile-sort-button ::ng-deep .mdc-button__label {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+	}
+
+	.mobile-sort-button.mobile-sort-button_active {
+		--mdc-text-button-label-text-color: var(--color-accentedPalette-700);
+		color: var(--color-accentedPalette-700) !important;
 	}
 
 	.saved-filters-row__columns {
@@ -830,6 +1033,10 @@
 }
 
 @media (prefers-color-scheme: dark) and (width <= 600px) {
+	.mobile-sort-button {
+		color: rgba(255, 255, 255, 0.87);
+	}
+
 	.mobile-sort-button_active {
 		background: var(--color-accentedPalette-900);
 		border-color: var(--color-accentedPalette-600) !important;
@@ -1000,6 +1207,63 @@
 
 .table-surface {
 	margin-bottom: 72px;
+}
+
+@media (width <= 600px) {
+	.table-surface mat-paginator {
+		margin-top: 12px;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-outer-container,
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-container {
+		justify-content: space-between !important;
+		flex-wrap: nowrap !important;
+		min-height: 48px;
+		padding: 0 !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-page-size {
+		margin: 0 !important;
+		padding: 0 !important;
+		margin-right: auto !important;
+		flex: 0 0 auto;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-page-size-label {
+		margin: 0 4px 0 0 !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-page-size-select {
+		margin: 0 8px 0 0 !important;
+		width: auto !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-form-field-infix {
+		width: auto !important;
+		min-width: 36px !important;
+		padding-right: 4px !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-select {
+		width: auto !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-select-arrow-wrapper {
+		padding-left: 6px !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-page-size-select .mat-mdc-text-field-wrapper {
+		padding: 0 10px !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-range-actions {
+		flex: 0 0 auto;
+		margin: 0 !important;
+	}
+
+	.table-surface mat-paginator ::ng-deep .mat-mdc-paginator-range-label {
+		margin: 0 4px !important;
+	}
 }
 
 @media (prefers-color-scheme: dark) {

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.css
@@ -776,7 +776,7 @@
 		align-items: center;
 		border: 1px solid var(--mdc-outlined-button-outline-color, rgba(0, 0, 0, 0.12));
 		background: transparent;
-		color: var(--color-primaryPalette-700);
+		color: rgba(0, 0, 0, 0.87);
 		font-size: 13px;
 		font-weight: 500;
 		padding: 0 8px 0 12px;
@@ -817,7 +817,7 @@
 	@media (prefers-color-scheme: dark) {
 		.search-row__quick-chip {
 			border-color: var(--mdc-outlined-button-outline-color, rgba(255, 255, 255, 0.24));
-			color: var(--color-primaryPalette-100);
+			color: rgba(255, 255, 255, 0.87);
 		}
 	}
 
@@ -919,6 +919,11 @@
 }
 
 @media (width <= 600px) {
+	.skeleton.mat-elevation-z4 {
+		box-shadow: none !important;
+		background: transparent !important;
+	}
+
 	.saved-filters-row {
 		display: flex;
 		flex-wrap: wrap;

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.html
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.html
@@ -98,6 +98,56 @@
                         <mat-icon fontSet="material-symbols-outlined">filter_list</mat-icon>
                         Filter
                     </button>
+                    <ng-container *ngIf="canEditConnection() && tableData && tableData.structure">
+                        <span class="search-row__divider" aria-hidden="true"></span>
+                        <button *ngIf="!savedFiltersPanel?.savedFilterData?.length"
+                            mat-stroked-button type="button"
+                            class="search-row__create-fast-filter"
+                            angulartics2On="click"
+                            angularticsAction="Saved filters: create new filter is clicked"
+                            (click)="handleOpenCreateQuickFilter(); posthog.capture('Saved filters: create new filter is clicked')">
+                            <mat-icon fontSet="material-symbols-outlined">add</mat-icon>
+                            Create fast filter
+                        </button>
+                    </ng-container>
+                    <div *ngIf="isMobileView && savedFiltersPanel?.savedFilterData?.length"
+                        class="search-row__quick-chips-slot">
+                        <div class="search-row__quick-chips">
+                            <button *ngIf="canEditConnection()" type="button"
+                                mat-icon-button
+                                class="search-row__add-quick-filter"
+                                matTooltip="Create new fast filter"
+                                angulartics2On="click"
+                                angularticsAction="Saved filters: create new filter is clicked"
+                                (click)="handleOpenCreateQuickFilter(); posthog.capture('Saved filters: create new filter is clicked')">
+                                <mat-icon fontSet="material-symbols-outlined">add</mat-icon>
+                            </button>
+                            <div *ngFor="let f of savedFiltersPanel?.savedFilterData"
+                                class="search-row__quick-chip"
+                                [class.search-row__quick-chip_active]="savedFiltersPanel?.selectedFilterSetId === f.id"
+                                (click)="savedFiltersPanel?.selectFiltersSet(f.id)">
+                                <span class="search-row__quick-chip-label">{{ f.name }}</span>
+                                <button *ngIf="canEditConnection()" type="button"
+                                    class="search-row__quick-chip-menu"
+                                    [matMenuTriggerFor]="quickChipMenu"
+                                    (click)="$event.stopPropagation(); chipFilterForMenu = f">
+                                    <mat-icon>more_vert</mat-icon>
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <mat-menu #quickChipMenu="matMenu">
+                        <button mat-menu-item type="button"
+                            (click)="savedFiltersPanel?.handleEditFilter(chipFilterForMenu)">
+                            <mat-icon fontSet="material-symbols-outlined">create</mat-icon>
+                            <span>Edit</span>
+                        </button>
+                        <button mat-menu-item type="button"
+                            (click)="savedFiltersPanel?.handleDeleteFilter(chipFilterForMenu)">
+                            <mat-icon fontSet="material-symbols-outlined">delete</mat-icon>
+                            <span>Delete</span>
+                        </button>
+                    </mat-menu>
                 </div>
             </div>
             <div class="actions">
@@ -504,7 +554,7 @@
     <div *ngIf="tableData.isEmptyTable && (getFiltersCount(activeFilters) || hasSavedFilterActive) && !searchString" class="empty-table">
         <mat-icon class="empty-table__icon">filter_list_off</mat-icon>
         <p class="mat-body-1">
-            {{ hasSavedFilterActive ? 'No records match the selected fast filter.' : 'No records match this filter.' }}
+            {{ hasSavedFilterActive ? 'No records match the selected fast filter' : 'No records match this filter' }}
         </p>
     </div>
 

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
@@ -198,7 +198,7 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 		private cdr: ChangeDetectorRef,
 		private paginatorIntl: MatPaginatorIntl,
 	) {
-		this.paginatorIntl.itemsPerPageLabel = 'per page:';
+		this.paginatorIntl.itemsPerPageLabel = 'Per page:';
 		this.paginatorIntl.changes.next();
 	}
 

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
@@ -28,7 +28,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatPaginator, MatPaginatorModule } from '@angular/material/paginator';
+import { MatPaginator, MatPaginatorIntl, MatPaginatorModule } from '@angular/material/paginator';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
@@ -179,6 +179,9 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 
 	@ViewChild(MatPaginator) paginator: MatPaginator;
 	@ViewChild(MatSort) sort: MatSort;
+	@ViewChild(SavedFiltersPanelComponent) savedFiltersPanel?: SavedFiltersPanelComponent;
+
+	public chipFilterForMenu: any = null;
 
 	public defaultSort: { column: string; direction: 'asc' | 'desc' } | null = null;
 	private sortInitialized: boolean = false;
@@ -193,7 +196,11 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 		public router: Router,
 		public dialog: MatDialog,
 		private cdr: ChangeDetectorRef,
-	) {}
+		private paginatorIntl: MatPaginatorIntl,
+	) {
+		this.paginatorIntl.itemsPerPageLabel = 'Rows per page:';
+		this.paginatorIntl.changes.next();
+	}
 
 	ngAfterViewInit() {
 		this.tableData.paginator = this.paginator;
@@ -586,6 +593,10 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 		this.searchString = '';
 	}
 
+	handleOpenCreateQuickFilter() {
+		this.savedFiltersPanel?.handleOpenSavedFiltersDialog();
+	}
+
 	handleSearch() {
 		this.searchString = this.searchString.trim();
 		this.staticSearchString = this.searchString;
@@ -898,6 +909,7 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 	handleActiveFilterClick(filterKey: string) {
 		const dialogRef = this.dialog.open(DbTableFiltersDialogComponent, {
 			width: '56em',
+			panelClass: 'mobile-bottom-sheet-dialog',
 			data: {
 				connectionID: this.connectionID,
 				tableName: this.name,

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
@@ -198,7 +198,7 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 		private cdr: ChangeDetectorRef,
 		private paginatorIntl: MatPaginatorIntl,
 	) {
-		this.paginatorIntl.itemsPerPageLabel = 'Rows per page:';
+		this.paginatorIntl.itemsPerPageLabel = 'per page:';
 		this.paginatorIntl.changes.next();
 	}
 
@@ -301,6 +301,11 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 	ngOnInit() {
 		this.searchString = this.route.snapshot.queryParams.search;
 		// this.hasSavedFilterActive = !!this.route.snapshot.queryParams.saved_filter;
+
+		// On mobile, never restore a previously open AI panel — user should land on the table, not the chat.
+		if (this.isMobileView) {
+			this._tableState.closeAIpanel();
+		}
 
 		const connectionType = this._connections.currentConnection.type;
 		this.displayCellComponents = tableDisplayTypes[connectionType];

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-widgets/db-table-widgets.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-widgets/db-table-widgets.component.css
@@ -31,6 +31,10 @@
 	gap: 16px;
 }
 
+.mobile-header {
+	display: none;
+}
+
 .widget-settings {
 	display: grid;
 	grid-template-columns: minmax(10%, 130px) 1fr 2fr 1fr 2fr 50px;
@@ -69,5 +73,157 @@
 	.actions {
 		--shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
 		--background-color: #fff;
+	}
+}
+
+@media (width <= 600px) {
+	.wrapper {
+		width: 100%;
+		margin: 0 auto 88px;
+		padding: 0 16px;
+		min-width: 0;
+	}
+
+	.row-breadcrumbs {
+		display: none !important;
+	}
+
+	.mobile-header {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin: 20px 0 12px -12px;
+	}
+
+	.mobile-header__back {
+		margin-right: 0;
+	}
+
+	.mobile-header__titles {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	.mobile-header__title {
+		margin: 0 !important;
+		padding: 0 !important;
+		font-size: 18px !important;
+		font-weight: 600 !important;
+		line-height: 18px !important;
+	}
+
+	.mobile-header__subtitle {
+		display: block;
+		margin: 4px 0 0 !important;
+		padding: 0 !important;
+		font-size: 12px;
+		line-height: 14px;
+		color: rgba(0, 0, 0, 0.54);
+		font-weight: 400;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.actions__back {
+		display: none !important;
+	}
+
+	.actions {
+		justify-content: flex-end;
+	}
+
+	.header {
+		flex-direction: column;
+		gap: 12px;
+		margin: 16px 0 16px;
+	}
+
+	.header-actions-box {
+		width: 100%;
+		align-items: stretch;
+		gap: 8px;
+	}
+
+	.header-actions {
+		flex-wrap: wrap;
+		gap: 8px;
+		width: 100%;
+	}
+
+	.header-actions > button {
+		flex: 1 1 auto;
+	}
+
+	.header-links {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0;
+	}
+
+	.widget-settings {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	.widget-item {
+		display: block;
+		position: relative;
+		background: var(--mat-table-background-color, #fff);
+		border-radius: 12px;
+		padding: 16px 16px 8px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 1px 4px rgba(0, 0, 0, 0.04);
+	}
+
+	.widget-item ::ng-deep .mat-mdc-form-field {
+		width: 100%;
+	}
+
+	.widget-item ::ng-deep .widget-field-name {
+		display: block;
+		font-weight: 600;
+		margin: 0 0 12px 0;
+		font-size: 14px;
+	}
+
+	.widget-item ::ng-deep .widget-delete-button {
+		display: none !important;
+	}
+
+	.widget-item ::ng-deep .code-editor-box {
+		min-height: 140px;
+		margin-bottom: 16px;
+	}
+
+	.actions {
+		padding: 0 16px;
+		justify-content: space-between;
+		gap: 8px;
+	}
+
+	.actions > a,
+	.actions > button {
+		flex: 1 1 auto;
+	}
+
+	.actions_empty-state {
+		display: none !important;
+	}
+
+	.wrapper:has(app-widgets-empty-state) {
+		margin-bottom: 80px;
+	}
+}
+
+@media (prefers-color-scheme: dark) and (width <= 600px) {
+	.widget-item {
+		background: var(--surface-dark-color);
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 4px rgba(0, 0, 0, 0.2);
+	}
+
+	.mobile-header__subtitle {
+		color: rgba(255, 255, 255, 0.6);
 	}
 }

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-widgets/db-table-widgets.component.html
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-widgets/db-table-widgets.component.html
@@ -3,6 +3,15 @@
 
 <div *ngIf="widgets" class="wrapper">
     <header class="header">
+        <div class="mobile-header">
+            <a mat-icon-button class="mobile-header__back" routerLink="/dashboard/{{connectionID}}/{{tableName}}" aria-label="Back to table">
+                <mat-icon>arrow_back</mat-icon>
+            </a>
+            <div class="mobile-header__titles">
+                <h1 class="mobile-header__title">Widgets</h1>
+                <span class="mobile-header__subtitle">{{ tableName }}</span>
+            </div>
+        </div>
         <app-breadcrumbs [crumbs]="getCrumbs(currentConnection.title || currentConnection.database)" class="row-breadcrumbs"></app-breadcrumbs>
 
         <div *ngIf="widgets.length" class="header-actions-box">
@@ -61,7 +70,7 @@
 
 
         <div class="actions">
-            <a mat-stroked-button routerLink="/dashboard/{{connectionID}}/{{tableName}}">
+            <a mat-stroked-button routerLink="/dashboard/{{connectionID}}/{{tableName}}" class="actions__back">
                 Back
             </a>
 
@@ -75,7 +84,7 @@
     <ng-template #emptyState>
         <app-widgets-empty-state (onAddWidget)="addNewWidget()"></app-widgets-empty-state>
 
-        <div class="actions">
+        <div class="actions actions_empty-state">
             <a mat-stroked-button routerLink="/dashboard/{{connectionID}}/{{tableName}}">
                 Back
             </a>

--- a/frontend/src/app/components/dashboard/db-table-view/db-table-widgets/widgets-empty-state/widgets-empty-state.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-widgets/widgets-empty-state/widgets-empty-state.component.css
@@ -357,3 +357,34 @@
 		color: rgba(255, 255, 255, 0.54);
 	}
 }
+
+@media (width <= 600px) {
+	.empty-state {
+		flex-direction: column;
+	}
+
+	.empty-divider,
+	.empty-right,
+	.empty-icon-box {
+		display: none !important;
+	}
+
+	.empty-left {
+		width: 100%;
+		max-width: 100%;
+		padding: 16px 0;
+	}
+
+	.empty-cta {
+		justify-content: flex-end;
+		gap: 12px;
+	}
+
+	.empty-cta > button {
+		order: 2;
+	}
+
+	.empty-cta > .empty-docs-link {
+		order: 1;
+	}
+}

--- a/frontend/src/app/components/dashboard/db-table-view/saved-filters-panel/saved-filters-panel.component.css
+++ b/frontend/src/app/components/dashboard/db-table-view/saved-filters-panel/saved-filters-panel.component.css
@@ -26,12 +26,7 @@
 }
 
 @media (width <= 600px) {
-	.saved-filters-trigger {
-		display: inline-flex;
-	}
-
-	.create-filter-button,
-	.saved-filters-tabs {
+	.saved-filters-list {
 		display: none !important;
 	}
 }
@@ -297,11 +292,12 @@
 
 @media (width <= 600px) {
 	.filters-container {
+		display: flex;
 		align-items: center;
 		flex-direction: row;
 		flex-wrap: wrap;
-		gap: 6px;
-		margin: 8px 0 16px;
+		gap: 6px 8px;
+		margin: 4px 0 0;
 		padding: 8px 16px;
 		border-radius: 10px;
 		background: rgba(0, 0, 0, 0.03);
@@ -310,6 +306,11 @@
 		min-width: 0;
 		overflow-x: clip;
 		overflow-y: visible;
+	}
+
+	.filters-container > .static-filters {
+		align-items: center;
+		min-height: 32px;
 	}
 
 
@@ -412,6 +413,9 @@
 @media (width <= 600px) {
 	.filters-where-label {
 		margin-top: 0 !important;
+		min-height: 32px;
+		align-items: center;
+		line-height: 1;
 	}
 }
 

--- a/frontend/src/app/components/db-table-row-edit/db-table-row-edit.component.css
+++ b/frontend/src/app/components/db-table-row-edit/db-table-row-edit.component.css
@@ -189,8 +189,7 @@
 }
 
 .widget {
-	display: grid;
-	grid-template-columns: 0 1fr 36px;
+	display: block;
 }
 
 .widget-info {

--- a/frontend/src/app/components/skeletons/placeholder-table-data/placeholder-table-data.component.css
+++ b/frontend/src/app/components/skeletons/placeholder-table-data/placeholder-table-data.component.css
@@ -14,3 +14,59 @@
 .table-cell-content {
 	height: 24px;
 }
+
+.data-table_mobile {
+	display: none;
+}
+
+@media (width <= 600px) {
+	.data-table_desktop {
+		display: none;
+	}
+
+	:host {
+		display: block;
+		box-shadow: none !important;
+	}
+
+	.data-table_mobile {
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding: 0 0 16px;
+	}
+
+	.mobile-card {
+		background: var(--mat-table-background-color, #fff);
+		border: none;
+		border-radius: 12px;
+		padding: 12px 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+
+	.mobile-card__value {
+		width: 100%;
+		height: 14px;
+		border-radius: 4px;
+	}
+
+	.mobile-card__value_short {
+		width: 30%;
+	}
+
+	.mobile-card__value_medium {
+		width: 60%;
+	}
+
+	.mobile-card__value_long {
+		width: 80%;
+	}
+}
+
+@media (prefers-color-scheme: dark) and (width <= 600px) {
+	.mobile-card {
+		background: var(--surface-dark-color);
+	}
+}

--- a/frontend/src/app/components/skeletons/placeholder-table-data/placeholder-table-data.component.html
+++ b/frontend/src/app/components/skeletons/placeholder-table-data/placeholder-table-data.component.html
@@ -1,5 +1,14 @@
-<div class="mat-elevation-z4 data-table">
+<div class="mat-elevation-z4 data-table data-table_desktop">
     <div *ngFor="let _ of numberOfDivs; let i = index" class="table-cell">
         <div class="bone table-cell-content"></div>
+    </div>
+</div>
+
+<div class="data-table_mobile">
+    <div *ngFor="let _ of numberOfCards; let i = index" class="mobile-card mat-elevation-z2">
+        <div class="bone mobile-card__value mobile-card__value_short"></div>
+        <div class="bone mobile-card__value"></div>
+        <div class="bone mobile-card__value mobile-card__value_medium"></div>
+        <div class="bone mobile-card__value mobile-card__value_long"></div>
     </div>
 </div>

--- a/frontend/src/app/components/skeletons/placeholder-table-data/placeholder-table-data.component.ts
+++ b/frontend/src/app/components/skeletons/placeholder-table-data/placeholder-table-data.component.ts
@@ -9,4 +9,5 @@ import { Component } from '@angular/core';
 })
 export class PlaceholderTableDataComponent {
 	public numberOfDivs = Array.from({ length: 42 }, (_, index) => index);
+	public numberOfCards = Array.from({ length: 6 }, (_, index) => index);
 }

--- a/frontend/src/app/components/users/cedar-policy-editor-dialog/cedar-policy-editor-dialog.component.html
+++ b/frontend/src/app/components/users/cedar-policy-editor-dialog/cedar-policy-editor-dialog.component.html
@@ -48,14 +48,14 @@
         }
     </mat-dialog-content>
     <mat-dialog-actions>
-        @if (editorMode() === 'form' && !formParseError() && !loading() && !policyList?.showAddForm) {
+        <button type="button" mat-flat-button (click)="confirmClose()">Cancel</button>
+        <span class="dialog-actions-spacer"></span>
+        @if (editorMode() === 'form' && !formParseError() && !loading() && !policyList?.showAddForm && policyList?.policies()?.length) {
             <button type="button" mat-button color="primary"
                 (click)="onAddPolicyClick()">
                 <mat-icon>add</mat-icon> Add policy
             </button>
         }
-        <span class="dialog-actions-spacer"></span>
-        <button type="button" mat-flat-button (click)="confirmClose()">Cancel</button>
         <button type="submit" mat-flat-button color="primary"
             [disabled]="submitting()">
             Save

--- a/frontend/src/app/components/users/cedar-policy-list/cedar-policy-list.component.css
+++ b/frontend/src/app/components/users/cedar-policy-list/cedar-policy-list.component.css
@@ -5,9 +5,17 @@
 }
 
 .empty-state {
-	opacity: 0.7;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 12px;
 	font-size: 14px;
 	padding: 12px 0;
+}
+
+.empty-state p {
+	margin: 0;
+	opacity: 0.7;
 }
 
 /* ── Group ── */

--- a/frontend/src/app/components/users/cedar-policy-list/cedar-policy-list.component.html
+++ b/frontend/src/app/components/users/cedar-policy-list/cedar-policy-list.component.html
@@ -5,7 +5,12 @@
 
     @if (!loading() && policies().length === 0 && !showAddForm) {
         <div class="empty-state">
-            No policies defined. Add a policy to grant permissions.
+            <p>No policies defined. Add a policy to grant permissions.</p>
+            <button type="button" mat-flat-button color="accent"
+                (click)="showAddForm = true">
+                <mat-icon>add</mat-icon>
+                Add policy
+            </button>
         </div>
     }
 

--- a/frontend/src/app/components/users/user-add-dialog/user-add-dialog.component.html
+++ b/frontend/src/app/components/users/user-add-dialog/user-add-dialog.component.html
@@ -26,7 +26,6 @@
     }
   </mat-dialog-content>
   <mat-dialog-actions align="end">
-    <button type="button" mat-flat-button mat-dialog-close>Cancel</button>
     @if (data.availableMembers.length) {
       <button type="submit"
         mat-flat-button color="primary"
@@ -40,5 +39,6 @@
         Open Company page
       </a>
     }
+    <button type="button" mat-flat-button mat-dialog-close>Cancel</button>
   </mat-dialog-actions>
 </form>

--- a/frontend/src/app/components/users/users.component.css
+++ b/frontend/src/app/components/users/users.component.css
@@ -112,20 +112,34 @@ header {
 	}
 }
 
+.user {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 8px 0;
+}
+
+.user__label {
+	display: flex;
+	flex-direction: column;
+}
+
+.user__email {
+	font-size: 12px;
+	color: rgba(0, 0, 0, 0.64);
+}
+
+@media (prefers-color-scheme: dark) {
+	.user__email {
+		color: rgba(255, 255, 255, 0.64);
+	}	
+}
+
 .group-members-count {
 	font-size: 11px;
 	opacity: 0.45;
 	margin-left: 6px;
 	white-space: nowrap;
-}
-
-.user {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	box-sizing: border-box;
-	padding-right: 1.5em;
-	width: calc(100% + 1em);
 }
 
 .no-access {

--- a/frontend/src/app/components/users/users.component.css
+++ b/frontend/src/app/components/users/users.component.css
@@ -131,3 +131,25 @@ header {
 .no-access {
 	margin-top: 32px !important;
 }
+
+@media (width <= 600px) {
+	.wrapper {
+		width: 100%;
+		padding: 0 16px;
+		box-sizing: border-box;
+	}
+
+	header {
+		flex-wrap: wrap;
+		gap: 8px;
+		margin: 16px 0 12px;
+	}
+
+	.add-group-button {
+		flex: 0 0 auto;
+	}
+
+	.mat-h1 {
+		font-size: 22px;
+	}
+}

--- a/frontend/src/app/components/users/users.component.html
+++ b/frontend/src/app/components/users/users.component.html
@@ -96,30 +96,32 @@
                     @if (groupUsers()[groupItem.group.id] === 'empty') {
                         <p class="body-2">No users in the group</p>
                     }
-                    <mat-list role="list">
+                    <ul>
                         @if (getGroupUsers(groupItem.group.id); as usersList) {
                             @for (user of usersList; track user.email) {
-                                <mat-list-item role="listitem">
-                                    <div class="user">
+                                <li class="user">
+                                    <div class="user__label">
                                         @if (user.name) {
-                                            <span>{{user.name}} ({{user.email}})</span>
+                                            <span class="user__name">{{user.name}}</span>
+                                            <span class="user__email">{{user.email}}</span>
                                         } @else {
-                                            <span>{{user.email}}</span>
-                                        }
-                                        @if (currentUser()?.email !== user.email && canManage()) {
-                                            <button type="button" mat-icon-button
-                                                angulartics2On="click"
-                                                angularticsAction="Users access: delete user is clicked"
-                                                matTooltip="Delete user"
-                                                (click)="openDeleteUserDialog(user, groupItem.group); posthog.capture('Users access: delete user is clicked')">
-                                                <mat-icon>person_remove</mat-icon>
-                                            </button>
+                                            <span class="user__name">{{user.email}}</span>
                                         }
                                     </div>
-                                </mat-list-item>
+                                    
+                                    @if (currentUser()?.email !== user.email && canManage()) {
+                                        <button matListItemMeta type="button" mat-icon-button
+                                            angulartics2On="click"
+                                            angularticsAction="Users access: delete user is clicked"
+                                            matTooltip="Delete user"
+                                            (click)="openDeleteUserDialog(user, groupItem.group); posthog.capture('Users access: delete user is clicked')">
+                                            <mat-icon>person_remove</mat-icon>
+                                        </button>
+                                    }
+                                </li>
                             }
                         }
-                    </mat-list>
+                    </ul>
                 </mat-expansion-panel>
             }
         </mat-accordion>

--- a/frontend/src/app/components/users/users.component.ts
+++ b/frontend/src/app/components/users/users.component.ts
@@ -157,6 +157,7 @@ export class UsersComponent implements OnInit {
 			if (createdGroup) {
 				this._dialog.open(CedarPolicyEditorDialogComponent, {
 					width: '40em',
+					panelClass: 'mobile-bottom-sheet-dialog',
 					data: { groupId: createdGroup.id, groupTitle: createdGroup.title, cedarPolicy: null },
 				});
 			}
@@ -194,6 +195,7 @@ export class UsersComponent implements OnInit {
 	openCedarPolicyDialog(group: UserGroup) {
 		this._dialog.open(CedarPolicyEditorDialogComponent, {
 			width: '40em',
+			panelClass: 'mobile-bottom-sheet-dialog',
 			data: { groupId: group.id, groupTitle: group.title, cedarPolicy: group.cedarPolicy },
 		});
 	}

--- a/frontend/src/app/services/configuration-state.service.ts
+++ b/frontend/src/app/services/configuration-state.service.ts
@@ -5,12 +5,9 @@ import { environment } from '../../environments/environment';
 import { NotificationsService } from './notifications.service';
 
 export interface ConfigProgress {
-	current?: number;
-	total?: number;
-	table?: string;
-	step?: string;
+	type: 'message' | 'complete' | 'error';
+	text?: string;
 	message?: string;
-	done?: boolean;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -20,6 +17,13 @@ export class ConfigurationStateService {
 
 	/** Latest progress event from the streaming setup endpoint (null when idle). */
 	public progress$ = new BehaviorSubject<ConfigProgress | null>(null);
+
+	private _queue: ConfigProgress[] = [];
+	private _drainTimer: ReturnType<typeof setInterval> | null = null;
+	private _currentDrainIntervalMs = 400;
+	private readonly _drainIntervalMsNormal = 400;
+	private readonly _drainIntervalMsFast = 80;
+	private readonly _drainCapAfterCompleteMs = 1500;
 
 	/** Start configuring — opens a streaming connection, parses progress events, resolves when complete. */
 	startConfiguring(connectionId: string): Promise<boolean> {
@@ -38,10 +42,19 @@ export class ConfigurationStateService {
 	}
 
 	private async _runSetup(connectionId: string): Promise<boolean> {
-		this.progress$.next({ message: 'Starting configuration…' });
+		this._queue = [];
+		this._stopDrain();
+		this._currentDrainIntervalMs = this._drainIntervalMsNormal;
+		this._enqueue({ type: 'message', text: 'Starting configuration…' });
 		try {
 			const url = `${environment.apiRoot || '/api'}/ai/v2/setup/${connectionId}`;
-			const response = await fetch(url, { method: 'GET', credentials: 'include' });
+			// Bypassing HttpClient (we need ReadableStream for SSE), so we replicate the masterpwd header that TokenInterceptor would normally inject.
+			const masterpwd = localStorage.getItem(`${connectionId}__masterKey`) || '';
+			const response = await fetch(url, {
+				method: 'GET',
+				credentials: 'include',
+				headers: { masterpwd },
+			});
 
 			if (!response.ok) {
 				throw new Error(`Setup failed with status ${response.status}`);
@@ -55,7 +68,7 @@ export class ConfigurationStateService {
 					const { done, value } = await reader.read();
 					if (done) {
 						const tail = buffer.trim();
-						if (tail) this._parseAndEmit(tail);
+						if (tail) this._parseAndEnqueue(tail);
 						break;
 					}
 					buffer += decoder.decode(value, { stream: true });
@@ -64,33 +77,104 @@ export class ConfigurationStateService {
 						const line = buffer.slice(0, newlineIdx).trim();
 						buffer = buffer.slice(newlineIdx + 1);
 						if (!line) continue;
-						this._parseAndEmit(line);
+						this._parseAndEnqueue(line);
 					}
 				}
 			}
 
+			await this._waitForDrain();
 			this._notifications.showSuccessSnackbar('All tables have been configured.');
 			return true;
-		} catch {
-			this._notifications.showSuccessSnackbar('Configuration could not be completed.');
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Configuration could not be completed.';
+			this._queue = [];
+			this._stopDrain();
+			this.progress$.next({ type: 'error', message });
+			this._notifications.showErrorSnackbar(message);
 			return false;
 		} finally {
 			const current = this._configuring.value;
 			current.delete(connectionId);
 			this._configuring.next(current);
-			this.progress$.next(null);
 		}
 	}
 
-	private _parseAndEmit(line: string): void {
+	private _parseAndEnqueue(line: string): void {
 		// Support SSE-style `data: {...}` lines as well as raw JSON lines.
 		const payload = line.startsWith('data:') ? line.slice(5).trim() : line;
 		if (!payload || payload === '[DONE]') return;
 		try {
 			const parsed = JSON.parse(payload) as ConfigProgress;
-			this.progress$.next(parsed);
+			// `complete` keeps order with the trailing messages but speeds up drain
+			// so the remaining log flushes quickly instead of pacing at the normal rate.
+			if (parsed.type === 'complete') {
+				this._enqueue({ type: 'message', text: '✓ Setup complete' });
+				this._enqueue(parsed);
+				this._switchDrainSpeed(this._drainIntervalMsFast);
+				return;
+			}
+			this._enqueue(parsed);
 		} catch {
 			// Ignore non-JSON keepalive/comment frames.
 		}
+	}
+
+	private _enqueue(p: ConfigProgress): void {
+		this._queue.push(p);
+		this._startDrain();
+	}
+
+	private _startDrain(): void {
+		if (this._drainTimer) return;
+		// Emit first item immediately, then pace the rest.
+		this._drainOne();
+		this._drainTimer = setInterval(() => this._drainOne(), this._currentDrainIntervalMs);
+	}
+
+	private _switchDrainSpeed(intervalMs: number): void {
+		this._currentDrainIntervalMs = intervalMs;
+		if (this._drainTimer) {
+			clearInterval(this._drainTimer);
+			this._drainTimer = setInterval(() => this._drainOne(), intervalMs);
+		}
+	}
+
+	private _drainOne(): void {
+		const next = this._queue.shift();
+		if (!next) {
+			this._stopDrain();
+			return;
+		}
+		this.progress$.next(next);
+	}
+
+	private _stopDrain(): void {
+		if (this._drainTimer) {
+			clearInterval(this._drainTimer);
+			this._drainTimer = null;
+		}
+	}
+
+	private _waitForDrain(): Promise<void> {
+		// Switch to fast drain on stream end so we don't add long display tail.
+		this._switchDrainSpeed(this._drainIntervalMsFast);
+		const start = Date.now();
+		return new Promise((resolve) => {
+			const check = (): void => {
+				if (this._queue.length === 0 && !this._drainTimer) {
+					resolve();
+					return;
+				}
+				if (Date.now() - start >= this._drainCapAfterCompleteMs) {
+					// Cap reached — flush whatever is left so we don't delay navigation further.
+					while (this._queue.length > 0) this._drainOne();
+					this._stopDrain();
+					resolve();
+					return;
+				}
+				setTimeout(check, this._drainIntervalMsFast);
+			};
+			check();
+		});
 	}
 }

--- a/frontend/src/app/services/configuration-state.service.ts
+++ b/frontend/src/app/services/configuration-state.service.ts
@@ -1,16 +1,27 @@
 import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
-import { ApiService } from './api.service';
+import { environment } from '../../environments/environment';
 import { NotificationsService } from './notifications.service';
+
+export interface ConfigProgress {
+	current?: number;
+	total?: number;
+	table?: string;
+	step?: string;
+	message?: string;
+	done?: boolean;
+}
 
 @Injectable({ providedIn: 'root' })
 export class ConfigurationStateService {
-	private _api = inject(ApiService);
 	private _notifications = inject(NotificationsService);
 	private _configuring = new BehaviorSubject<Set<string>>(new Set());
 
-	/** Start configuring — fires the API and manages state. Returns a promise that resolves when setup completes. */
+	/** Latest progress event from the streaming setup endpoint (null when idle). */
+	public progress$ = new BehaviorSubject<ConfigProgress | null>(null);
+
+	/** Start configuring — opens a streaming connection, parses progress events, resolves when complete. */
 	startConfiguring(connectionId: string): Promise<boolean> {
 		if (this._configuring.value.has(connectionId)) return Promise.resolve(false);
 
@@ -27,8 +38,37 @@ export class ConfigurationStateService {
 	}
 
 	private async _runSetup(connectionId: string): Promise<boolean> {
+		this.progress$.next({ message: 'Starting configuration…' });
 		try {
-			await this._api.get<string>(`/ai/v2/setup/${connectionId}`, { responseType: 'text' });
+			const url = `${environment.apiRoot || '/api'}/ai/v2/setup/${connectionId}`;
+			const response = await fetch(url, { method: 'GET', credentials: 'include' });
+
+			if (!response.ok) {
+				throw new Error(`Setup failed with status ${response.status}`);
+			}
+
+			if (response.body) {
+				const reader = response.body.getReader();
+				const decoder = new TextDecoder();
+				let buffer = '';
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) {
+						const tail = buffer.trim();
+						if (tail) this._parseAndEmit(tail);
+						break;
+					}
+					buffer += decoder.decode(value, { stream: true });
+					let newlineIdx: number;
+					while ((newlineIdx = buffer.indexOf('\n')) >= 0) {
+						const line = buffer.slice(0, newlineIdx).trim();
+						buffer = buffer.slice(newlineIdx + 1);
+						if (!line) continue;
+						this._parseAndEmit(line);
+					}
+				}
+			}
+
 			this._notifications.showSuccessSnackbar('All tables have been configured.');
 			return true;
 		} catch {
@@ -38,6 +78,19 @@ export class ConfigurationStateService {
 			const current = this._configuring.value;
 			current.delete(connectionId);
 			this._configuring.next(current);
+			this.progress$.next(null);
+		}
+	}
+
+	private _parseAndEmit(line: string): void {
+		// Support SSE-style `data: {...}` lines as well as raw JSON lines.
+		const payload = line.startsWith('data:') ? line.slice(5).trim() : line;
+		if (!payload || payload === '[DONE]') return;
+		try {
+			const parsed = JSON.parse(payload) as ConfigProgress;
+			this.progress$.next(parsed);
+		} catch {
+			// Ignore non-JSON keepalive/comment frames.
 		}
 	}
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -89,6 +89,10 @@ body {
     }
 }
 
+body:has(.ai-panel-sidebar-content_open) .add-row-fab {
+    display: none !important;
+}
+
 @keyframes shimmer {
     100% {
         transform: translateX(100%);


### PR DESCRIPTION
## Summary

Two commits on top of `main` (#1814 was already merged):

- **`8cedb7754` quick-filter chips inline**: horizontal-scroll saved-filter chips in the search row, "+" / "Create fast filter" trigger with vertical divider, three-dot menu on each chip wired to the panel, conditions editor on its own row via :has(), tightened spacing and Sort by text color, paginator with "Rows per page:" → "per page:" label, items-per-page flush left, range/buttons right
- **`0893e98a4` widgets page + AI panel + sidebar polish**: mobile widget cards layout with arrow-back header + table name, hide breadcrumbs and per-card delete on mobile, empty state cleanups (icon hidden, Docs+Create right-aligned together, symmetric padding, no Back button at the bottom), AI Insights forced full-size only and reset when navigating away, FAB Add row hides while chat is open, sidebar drawer sits below the nav header on mobile + hides dark toolbar, Hosted databases added between Company and Secrets, smaller account-section items, Upgrade nudged up, logo shortens only inside a connection, mobile loading skeleton cards, row preview dividers inset to text width, filter-edit dialog opens as bottom sheet from active-filter chip tap

## Test plan

- [ ] On mobile, search row shows `[Filter] │ [+ chip chip chip →]` and chips scroll horizontally inside their slot only (no page-wide horizontal scroll)
- [ ] Tap chip three-dots → Edit / Delete works, conditions editor appears on its own row below
- [ ] Widgets page: arrow-back + "Widgets" / table-name header, each widget is a card, no delete on cards, only "Save" at the bottom
- [ ] Widgets empty state: no icon/breadcrumbs/back button, Docs + Create right-aligned, no overlap with version footer
- [ ] AI Insights opens as full-size, no expand/collapse icon, title is just "AI insights", FAB Add row disappears while open, navigating away resets it on mobile
- [ ] Sidebar drawer opens below the nav header; "Connections" hidden inside a connection; Hosted databases visible between Company and Secrets; account-section items smaller; Upgrade closer to Log out
- [ ] Logo: short on mobile only inside a connection; full wordmark on connections-list/account/hosted-databases
- [ ] Paginator: "per page: [select]" flush left, range/buttons flush right
- [ ] Loading skeleton on mobile: vertical card stack, no left label column, no elevation around it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick filter chips and "Create fast filter" (mobile); "Hosted databases" in connections menu; expanded account menu; AI panel now opens by default; richer auto-configure progress UI.

* **UI & Style**
  * Broad mobile responsiveness (≤600px): sidenav, toolbar, widgets, table controls, paginator, dialogs, mobile card-style skeletons, and refined sidebar/account/AI styling.

* **Other**
  * Mobile audit feed with grouped logs and updated paginator labels; improved mobile dialog presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->