### PR TITLE
mobile: keep paginator within viewport, smarter first-page button

### DIFF
--- a/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
+++ b/frontend/src/app/components/dashboard/db-table-view/db-table-view.component.ts
@@ -198,7 +198,7 @@ export class DbTableViewComponent implements OnInit, OnChanges {
 		private cdr: ChangeDetectorRef,
 		private paginatorIntl: MatPaginatorIntl,
 	) {
-		this.paginatorIntl.itemsPerPageLabel = 'Rows per page:';
+		this.paginatorIntl.itemsPerPageLabel = 'Per page:';
 		this.paginatorIntl.changes.next();
 	}
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -243,4 +243,27 @@ body:has(.ai-panel-sidebar-content_open) .add-row-fab {
     app-db-table-view .field-copy-button {
         display: none !important;
     }
+
+    /* Last-page button always hidden on mobile — would push the paginator wider
+       than the viewport (causing page-wide horizontal scroll) once the range
+       label gets long (e.g. "1 – 30 of 5000"). Prev/Next is enough on mobile. */
+    .mat-mdc-paginator-navigation-last {
+        display: none !important;
+    }
+
+    /* First-page button only visible when there is a previous page (i.e., not on
+       page 1). Material marks it disabled on page 1, which we use as a hook
+       via multiple attribute/class names depending on Material version. */
+    .mat-mdc-paginator-navigation-first[disabled],
+    .mat-mdc-paginator-navigation-first[aria-disabled="true"],
+    .mat-mdc-paginator-navigation-first.mat-mdc-button-disabled,
+    .mat-mdc-paginator-navigation-first.mdc-icon-button--disabled {
+        display: none !important;
+    }
+
+    /* Wrap the long range label so the paginator stays within the viewport. */
+    .mat-mdc-paginator .mat-mdc-paginator-range-label {
+        white-space: nowrap;
+        font-size: 12px;
+    }
 }


### PR DESCRIPTION
## Summary

Fix the mobile paginator so it stops pushing the page into horizontal scroll on large tables, and bring back the « first-page button only when it's actually useful.

- Hide the last-page button on mobile (it was the main culprit — the "1 – 30 of 5000" label plus all four nav buttons no longer fit at narrow widths)
- First-page button now hidden only while disabled (i.e. on page 1); it appears as soon as the user paginates past page 1 and disappears again after navigating back via it. Selector covers all the disabled markers Material uses across versions (`[disabled]`, `[aria-disabled="true"]`, `.mat-mdc-button-disabled`, `.mdc-icon-button--disabled`)
- Unify the table paginator label "Rows per page:" → "Per page:" to match the audit page

## Test plan

- [ ] Open a table with many rows on a mobile viewport — no page-wide horizontal scroll
- [ ] Paginator shows `[Prev] N–M of K [Next]` on page 1; the « (first-page) button is not visible
- [ ] Tap Next — the « button now appears as `[« First] [Prev] N–M of K [Next]`
- [ ] Tap « First — page goes back to 1, the « button hides again
- [ ] The » (last-page) button is never visible on mobile
- [ ] Label reads "Per page:" on both the dashboard table and the audit table
- [ ] Desktop paginator is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated paginator label text for improved clarity
  * Enhanced mobile paginator display with optimized navigation button visibility and text overflow handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->