### PR TITLE
feat: add email verification flow for SaaS users

### DIFF
--- a/backend/src/entities/company-info/application/data-structures/accept-user-invitation-in-company.ds.ts
+++ b/backend/src/entities/company-info/application/data-structures/accept-user-invitation-in-company.ds.ts
@@ -3,3 +3,15 @@ export class AcceptUserValidationInCompany {
 	verificationString: string;
 	userPassword: string;
 }
+
+// IToken fields (the legacy controller sets them as cookies) plus the accepted user's identity,
+// so a satellite caller (rocketadmin-saas) can sign its own session cookie instead.
+export class AcceptedCompanyInvitationDs {
+	token: string;
+	exp: Date;
+	isTemporary: boolean;
+	userId: string;
+	userEmail: string;
+	userName: string | null;
+	companyId: string;
+}

--- a/backend/src/entities/company-info/application/data-structures/invite-user-in-company-and-connection-group.ds.ts
+++ b/backend/src/entities/company-info/application/data-structures/invite-user-in-company-and-connection-group.ds.ts
@@ -3,7 +3,11 @@ import { UserRoleEnum } from '../../../user/enums/user-role.enum.js';
 export class InviteUserInCompanyAndConnectionGroupDs {
 	inviterId: string;
 	companyId: string;
-	groupId: string;
+	groupId: string | null;
 	invitedUserEmail: string;
 	invitedUserCompanyRole: UserRoleEnum;
+	/** Satellite-provided prefix for the invitation link (already contains the company id in its path). */
+	inviteLinkBase?: string;
+	/** Satellite-provided prefix for the confirmation link the re-invite branch sends to inactive users. */
+	emailVerificationLinkBase?: string;
 }

--- a/backend/src/entities/company-info/use-cases/company-info-use-cases.interface.ts
+++ b/backend/src/entities/company-info/use-cases/company-info-use-cases.interface.ts
@@ -1,8 +1,10 @@
 import { InTransactionEnum } from '../../../enums/in-transaction.enum.js';
 import { SuccessResponse } from '../../../microservices/saas-microservice/data-structures/common-responce.ds.js';
 import { SimpleFoundUserInCompanyInfoDs } from '../../user/dto/found-user.dto.js';
-import { IToken } from '../../user/utils/generate-gwt-token.js';
-import { AcceptUserValidationInCompany } from '../application/data-structures/accept-user-invitation-in-company.ds.js';
+import {
+	AcceptedCompanyInvitationDs,
+	AcceptUserValidationInCompany,
+} from '../application/data-structures/accept-user-invitation-in-company.ds.js';
 import { AddCompanyTabTitleDs } from '../application/data-structures/add-company-tab-title.ds.js';
 import {
 	FoundUserCompanyInfoDs,
@@ -29,7 +31,10 @@ export interface IInviteUserInCompanyAndConnectionGroup {
 }
 
 export interface IVerifyInviteUserInCompanyAndConnectionGroup {
-	execute(inputData: AcceptUserValidationInCompany, inTransaction?: InTransactionEnum): Promise<IToken>;
+	execute(
+		inputData: AcceptUserValidationInCompany,
+		inTransaction?: InTransactionEnum,
+	): Promise<AcceptedCompanyInvitationDs>;
 }
 
 export interface IGetUserCompany {

--- a/backend/src/entities/company-info/use-cases/invite-user-in-company.use.case.ts
+++ b/backend/src/entities/company-info/use-cases/invite-user-in-company.use.case.ts
@@ -5,6 +5,7 @@ import { BaseType } from '../../../common/data-injection.tokens.js';
 import { Messages } from '../../../exceptions/text/messages.js';
 import { isSaaS } from '../../../helpers/app/is-saas.js';
 import { isTest } from '../../../helpers/app/is-test.js';
+import { ValidationHelper } from '../../../helpers/validators/validation-helper.js';
 import { SaasCompanyGatewayService } from '../../../microservices/gateways/saas-gateway.ts/saas-company-gateway.service.js';
 import { EmailService } from '../../email/email/email.service.js';
 import { WinstonLogger } from '../../logging/winston-logger.js';
@@ -79,6 +80,7 @@ export class InviteUserInCompanyAndConnectionGroupUseCase
 				foundInvitedUser.email,
 				rawToken,
 				companyCustomDomain,
+				ValidationHelper.resolveEmailVerificationLinkBase(inputData.emailVerificationLinkBase),
 			);
 
 			if (!sendEmailResult && !isTest() && !isSaaS()) {
@@ -115,6 +117,7 @@ export class InviteUserInCompanyAndConnectionGroupUseCase
 			companyId,
 			foundCompany.name,
 			companyCustomDomain,
+			ValidationHelper.resolveEmailVerificationLinkBase(inputData.inviteLinkBase),
 		);
 		const invitationRO: any = {
 			companyId: companyId,

--- a/backend/src/entities/company-info/use-cases/verify-invite-user-in-company.use.case.ts
+++ b/backend/src/entities/company-info/use-cases/verify-invite-user-in-company.use.case.ts
@@ -5,14 +5,17 @@ import { BaseType } from '../../../common/data-injection.tokens.js';
 import { Messages } from '../../../exceptions/text/messages.js';
 import { Encryptor } from '../../../helpers/encryption/encryptor.js';
 import { SaasCompanyGatewayService } from '../../../microservices/gateways/saas-gateway.ts/saas-company-gateway.service.js';
-import { generateGwtToken, IToken } from '../../user/utils/generate-gwt-token.js';
+import { generateGwtToken } from '../../user/utils/generate-gwt-token.js';
 import { get2FaScope } from '../../user/utils/is-jwt-scope-need.util.js';
-import { AcceptUserValidationInCompany } from '../application/data-structures/accept-user-invitation-in-company.ds.js';
+import {
+	AcceptedCompanyInvitationDs,
+	AcceptUserValidationInCompany,
+} from '../application/data-structures/accept-user-invitation-in-company.ds.js';
 import { IVerifyInviteUserInCompanyAndConnectionGroup } from './company-info-use-cases.interface.js';
 
 @Injectable({ scope: Scope.REQUEST })
 export class VerifyInviteUserInCompanyAndConnectionGroupUseCase
-	extends AbstractUseCase<AcceptUserValidationInCompany, IToken>
+	extends AbstractUseCase<AcceptUserValidationInCompany, AcceptedCompanyInvitationDs>
 	implements IVerifyInviteUserInCompanyAndConnectionGroup
 {
 	constructor(
@@ -23,7 +26,7 @@ export class VerifyInviteUserInCompanyAndConnectionGroupUseCase
 		super();
 	}
 
-	protected async implementation(inputData: AcceptUserValidationInCompany): Promise<IToken> {
+	protected async implementation(inputData: AcceptUserValidationInCompany): Promise<AcceptedCompanyInvitationDs> {
 		const { verificationString, userPassword, userName } = inputData;
 		const hashedToken = Encryptor.hashVerificationToken(verificationString);
 		const foundInvitation =
@@ -65,7 +68,18 @@ export class VerifyInviteUserInCompanyAndConnectionGroupUseCase
 			foundUser.isActive = true;
 			foundUser.role = role;
 			await this._dbContext.userRepository.saveUserEntity(foundUser);
-			return generateGwtToken(foundUser, get2FaScope(foundUser, foundInvitation.company), foundInvitation.company?.id);
+			const tokenInfo = generateGwtToken(
+				foundUser,
+				get2FaScope(foundUser, foundInvitation.company),
+				foundInvitation.company?.id,
+			);
+			return {
+				...tokenInfo,
+				userId: foundUser.id,
+				userEmail: foundUser.email,
+				userName: foundUser.name ?? null,
+				companyId,
+			};
 		}
 		const newUser = await this._dbContext.userRepository.saveRegisteringUser({
 			email: invitedUserEmail,
@@ -97,6 +111,17 @@ export class VerifyInviteUserInCompanyAndConnectionGroupUseCase
 		}
 		await this._dbContext.invitationInCompanyRepository.remove(foundInvitation);
 		await this.saasCompanyGatewayService.recountUsersInCompanyRequest(companyId);
-		return generateGwtToken(newUser, get2FaScope(newUser, foundInvitation.company), foundInvitation.company?.id);
+		const tokenInfo = generateGwtToken(
+			newUser,
+			get2FaScope(newUser, foundInvitation.company),
+			foundInvitation.company?.id,
+		);
+		return {
+			...tokenInfo,
+			userId: savedUser.id,
+			userEmail: savedUser.email,
+			userName: savedUser.name ?? null,
+			companyId,
+		};
 	}
 }

--- a/backend/src/entities/email/email/email.service.ts
+++ b/backend/src/entities/email/email/email.service.ts
@@ -147,10 +147,14 @@ export class EmailService {
 		companyId: string,
 		invitedCompanyName: string,
 		customCompanyDomain: string | null,
+		verificationLinkBase: string | null = null,
 	): Promise<SMTPTransport.SentMessageInfo | null> {
 		const currentYear = new Date().getFullYear();
 		const domain = customCompanyDomain ? customCompanyDomain : Constants.APP_DOMAIN_ADDRESS;
-		const link = `${domain}/company/${companyId}/verify/${verificationString}/`;
+		// A satellite-provided base already carries the company id in its path.
+		const link = verificationLinkBase
+			? `${verificationLinkBase}/${verificationString}`
+			: `${domain}/company/${companyId}/verify/${verificationString}/`;
 		const companyName = invitedCompanyName ? ` "${invitedCompanyName}" ` : ` `;
 		const letterContent: IMessage = {
 			from: this.emailFrom,
@@ -170,9 +174,12 @@ export class EmailService {
 		email: string,
 		verificationString: string,
 		customCompanyDomain: string | null,
+		verificationLinkBase: string | null = null,
 	): Promise<SMTPTransport.SentMessageInfo | null> {
 		const domain = customCompanyDomain ? customCompanyDomain : Constants.APP_DOMAIN_ADDRESS;
-		const link = `${domain}/external/user/email/verify/${verificationString}`;
+		const link = verificationLinkBase
+			? `${verificationLinkBase}/${verificationString}`
+			: `${domain}/external/user/email/verify/${verificationString}`;
 		const currentYear = new Date().getFullYear();
 		const letterContent: IMessage = {
 			from: this.emailFrom,
@@ -200,10 +207,13 @@ export class EmailService {
 		email: string,
 		requestString: string,
 		customCompanyDomain: string | null,
+		verificationLinkBase: string | null = null,
 	): Promise<SMTPTransport.SentMessageInfo | null> {
 		const currentYear = new Date().getFullYear();
 		const domain = customCompanyDomain ? customCompanyDomain : Constants.APP_DOMAIN_ADDRESS;
-		const linkToConfirm = `${domain}/external/user/email/change/verify/${requestString}`;
+		const linkToConfirm = verificationLinkBase
+			? `${verificationLinkBase}/${requestString}`
+			: `${domain}/external/user/email/change/verify/${requestString}`;
 		const letterContent: IMessage = {
 			from: this.emailFrom,
 			to: email,
@@ -218,10 +228,13 @@ export class EmailService {
 		email: string,
 		requestString: string,
 		customCompanyDomain: string | null,
+		verificationLinkBase: string | null = null,
 	): Promise<SMTPTransport.SentMessageInfo | null> {
 		const currentYear = new Date().getFullYear();
 		const domain = customCompanyDomain ? customCompanyDomain : Constants.APP_DOMAIN_ADDRESS;
-		const linkToConfirm = `${domain}/external/user/password/reset/verify/${requestString}`;
+		const linkToConfirm = verificationLinkBase
+			? `${verificationLinkBase}/${requestString}`
+			: `${domain}/external/user/password/reset/verify/${requestString}`;
 		const letterContent: IMessage = {
 			from: this.emailFrom,
 			to: email,

--- a/backend/src/entities/user/application/data-structures/request-email-change.ds.ts
+++ b/backend/src/entities/user/application/data-structures/request-email-change.ds.ts
@@ -1,0 +1,11 @@
+export class RequestEmailChangeDs {
+	userId: string;
+	/** Satellite-provided link prefix (see ValidationHelper.resolveEmailVerificationLinkBase). */
+	verificationLinkBase?: string;
+}
+
+export class RequestEmailVerificationDs {
+	userId: string;
+	/** Satellite-provided link prefix (see ValidationHelper.resolveEmailVerificationLinkBase). */
+	verificationLinkBase?: string;
+}

--- a/backend/src/entities/user/application/data-structures/usual-register-user.ds.ts
+++ b/backend/src/entities/user/application/data-structures/usual-register-user.ds.ts
@@ -24,4 +24,12 @@ export class SaasUsualUserRegisterDS extends UsualRegisterUserDs {
 
 	@ApiProperty({ required: false })
 	companyName?: string;
+
+	@ApiProperty({
+		required: false,
+		description:
+			'Full URL prefix the confirmation token is appended to (e.g. "https://app.sitenova.com/saas/user/email/verify"). ' +
+			'When omitted or not allowed, the legacy frontend link is built instead.',
+	})
+	emailVerificationLinkBase?: string;
 }

--- a/backend/src/entities/user/dto/request-rest-user-password.dto.ts
+++ b/backend/src/entities/user/dto/request-rest-user-password.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString, IsUUID } from 'class-validator';
+import { IsEmail, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class RequestRestUserPasswordDto {
 	@ApiProperty()
@@ -13,4 +13,14 @@ export class RequestRestUserPasswordDto {
 	@IsString()
 	@IsUUID()
 	companyId: string;
+
+	@ApiProperty({
+		required: false,
+		description:
+			'Full URL prefix the reset token is appended to (satellite-provided; validated against the SaaS ' +
+			'domain allowlist, otherwise the legacy frontend link is built).',
+	})
+	@IsOptional()
+	@IsString()
+	verificationLinkBase?: string;
 }

--- a/backend/src/entities/user/use-cases/request-change-user-email.use.case.ts
+++ b/backend/src/entities/user/use-cases/request-change-user-email.use.case.ts
@@ -3,14 +3,16 @@ import AbstractUseCase from '../../../common/abstract-use.case.js';
 import { IGlobalDatabaseContext } from '../../../common/application/global-database-context.interface.js';
 import { BaseType } from '../../../common/data-injection.tokens.js';
 import { Messages } from '../../../exceptions/text/messages.js';
+import { ValidationHelper } from '../../../helpers/validators/validation-helper.js';
 import { SaasCompanyGatewayService } from '../../../microservices/gateways/saas-gateway.ts/saas-company-gateway.service.js';
 import { EmailService } from '../../email/email/email.service.js';
 import { OperationResultMessageDs } from '../application/data-structures/operation-result-message.ds.js';
+import { RequestEmailChangeDs } from '../application/data-structures/request-email-change.ds.js';
 import { IRequestEmailChange } from './user-use-cases.interfaces.js';
 
 @Injectable()
 export class RequestChangeUserEmailUseCase
-	extends AbstractUseCase<string, OperationResultMessageDs>
+	extends AbstractUseCase<RequestEmailChangeDs, OperationResultMessageDs>
 	implements IRequestEmailChange
 {
 	constructor(
@@ -22,7 +24,8 @@ export class RequestChangeUserEmailUseCase
 		super();
 	}
 
-	protected async implementation(userId: string): Promise<OperationResultMessageDs> {
+	protected async implementation(inputData: RequestEmailChangeDs): Promise<OperationResultMessageDs> {
+		const { userId } = inputData;
 		const foundUser = await this._dbContext.userRepository.findOneUserById(userId);
 		if (!foundUser) {
 			throw new HttpException(
@@ -47,6 +50,7 @@ export class RequestChangeUserEmailUseCase
 			foundUser.email,
 			rawToken,
 			companyCustomDomain,
+			ValidationHelper.resolveEmailVerificationLinkBase(inputData.verificationLinkBase),
 		);
 		const resultMessage = mailingResult?.messageId
 			? Messages.EMAIL_CHANGE_REQUESTED_SUCCESSFULLY

--- a/backend/src/entities/user/use-cases/request-email-verification.use.case.ts
+++ b/backend/src/entities/user/use-cases/request-email-verification.use.case.ts
@@ -3,14 +3,16 @@ import AbstractUseCase from '../../../common/abstract-use.case.js';
 import { IGlobalDatabaseContext } from '../../../common/application/global-database-context.interface.js';
 import { BaseType } from '../../../common/data-injection.tokens.js';
 import { Messages } from '../../../exceptions/text/messages.js';
+import { ValidationHelper } from '../../../helpers/validators/validation-helper.js';
 import { SaasCompanyGatewayService } from '../../../microservices/gateways/saas-gateway.ts/saas-company-gateway.service.js';
 import { EmailService } from '../../email/email/email.service.js';
 import { OperationResultMessageDs } from '../application/data-structures/operation-result-message.ds.js';
+import { RequestEmailVerificationDs } from '../application/data-structures/request-email-change.ds.js';
 import { IRequestEmailVerification } from './user-use-cases.interfaces.js';
 
 @Injectable()
 export class RequestEmailVerificationUseCase
-	extends AbstractUseCase<string, OperationResultMessageDs>
+	extends AbstractUseCase<RequestEmailVerificationDs, OperationResultMessageDs>
 	implements IRequestEmailVerification
 {
 	constructor(
@@ -22,7 +24,8 @@ export class RequestEmailVerificationUseCase
 		super();
 	}
 
-	protected async implementation(userId: string): Promise<OperationResultMessageDs> {
+	protected async implementation(inputData: RequestEmailVerificationDs): Promise<OperationResultMessageDs> {
+		const { userId } = inputData;
 		const foundUser = await this._dbContext.userRepository.findOneUserWithEmailVerification(userId);
 		if (!foundUser) {
 			throw new HttpException(
@@ -44,7 +47,12 @@ export class RequestEmailVerificationUseCase
 		const companyCustomDomain = await this.saasCompanyGatewayService.getCompanyCustomDomainById(foundUserCompany.id);
 
 		const { rawToken } = await this._dbContext.emailVerificationRepository.createOrUpdateEmailVerification(foundUser);
-		await this.emailService.sendEmailConfirmation(foundUser.email, rawToken, companyCustomDomain);
+		await this.emailService.sendEmailConfirmation(
+			foundUser.email,
+			rawToken,
+			companyCustomDomain,
+			ValidationHelper.resolveEmailVerificationLinkBase(inputData.verificationLinkBase),
+		);
 		return { message: Messages.EMAIL_VERIFICATION_REQUESTED };
 	}
 }

--- a/backend/src/entities/user/use-cases/request-reset-user-password.use.case.ts
+++ b/backend/src/entities/user/use-cases/request-reset-user-password.use.case.ts
@@ -3,6 +3,7 @@ import AbstractUseCase from '../../../common/abstract-use.case.js';
 import { IGlobalDatabaseContext } from '../../../common/application/global-database-context.interface.js';
 import { BaseType } from '../../../common/data-injection.tokens.js';
 import { Messages } from '../../../exceptions/text/messages.js';
+import { ValidationHelper } from '../../../helpers/validators/validation-helper.js';
 import { SaasCompanyGatewayService } from '../../../microservices/gateways/saas-gateway.ts/saas-company-gateway.service.js';
 import { EmailService } from '../../email/email/email.service.js';
 import { OperationResultMessageDs } from '../application/data-structures/operation-result-message.ds.js';
@@ -42,6 +43,7 @@ export class RequestResetUserPasswordUseCase
 			foundUser.email,
 			rawToken,
 			companyCustomDomain,
+			ValidationHelper.resolveEmailVerificationLinkBase(emailData.verificationLinkBase),
 		);
 		const resultMessage = mailingResult?.messageId
 			? Messages.PASSWORD_RESET_REQUESTED_SUCCESSFULLY

--- a/backend/src/entities/user/use-cases/user-use-cases.interfaces.ts
+++ b/backend/src/entities/user/use-cases/user-use-cases.interfaces.ts
@@ -12,6 +12,10 @@ import {
 	OtpValidationResultDS,
 } from '../application/data-structures/otp-validation-result.ds.js';
 import { RegisteredUserDs } from '../application/data-structures/registered-user.ds.js';
+import {
+	RequestEmailChangeDs,
+	RequestEmailVerificationDs,
+} from '../application/data-structures/request-email-change.ds.js';
 import { ResetUsualUserPasswordDs } from '../application/data-structures/reset-usual-user-password.ds.js';
 import { SaveUserSettingsDs } from '../application/data-structures/save-user-settings.ds.js';
 import { ToggleConnectionDisplayModeDs } from '../application/data-structures/toggle-connection-display-mode.ds.js';
@@ -54,7 +58,7 @@ export interface IRequestPasswordReset {
 }
 
 export interface IRequestEmailChange {
-	execute(userId: string, inTransaction: InTransactionEnum): Promise<OperationResultMessageDs>;
+	execute(inputData: RequestEmailChangeDs, inTransaction: InTransactionEnum): Promise<OperationResultMessageDs>;
 }
 
 export interface IVerifyEmailChange {
@@ -62,7 +66,7 @@ export interface IVerifyEmailChange {
 }
 
 export interface IRequestEmailVerification {
-	execute(userId: string, inTransaction: InTransactionEnum): Promise<OperationResultMessageDs>;
+	execute(inputData: RequestEmailVerificationDs, inTransaction: InTransactionEnum): Promise<OperationResultMessageDs>;
 }
 
 export interface IDeleteUserAccount {

--- a/backend/src/entities/user/user.controller.ts
+++ b/backend/src/entities/user/user.controller.ts
@@ -259,7 +259,7 @@ export class UserController {
 	@Throttle({ default: { limit: isTest() ? 200 : 5, ttl: 60000 } })
 	@Get('user/email/verify/request')
 	async requestEmailVerification(@UserId() userId: string): Promise<OperationResultMessageDs> {
-		return await this.requestEmailVerificationUseCase.execute(userId, InTransactionEnum.ON);
+		return await this.requestEmailVerificationUseCase.execute({ userId }, InTransactionEnum.ON);
 	}
 
 	@ApiOperation({ summary: 'Verify user email' })
@@ -318,7 +318,7 @@ export class UserController {
 	@Throttle({ default: { limit: isTest() ? 200 : 5, ttl: 60000 } })
 	@Get('user/email/change/request/')
 	async askChangeUserEmail(@UserId() userId: string): Promise<OperationResultMessageDs> {
-		return await this.requestChangeUserEmailUseCase.execute(userId, InTransactionEnum.ON);
+		return await this.requestChangeUserEmailUseCase.execute({ userId }, InTransactionEnum.ON);
 	}
 
 	@ApiOperation({ summary: 'Verify user email change' })

--- a/backend/src/helpers/validators/validation-helper.ts
+++ b/backend/src/helpers/validators/validation-helper.ts
@@ -57,6 +57,49 @@ export class ValidationHelper {
 		return countries.isValid(countryCode);
 	}
 
+	// Normalizes a satellite-provided link base for use in an email: returns the base without
+	// trailing slashes when it passes the allowlist below, null otherwise (callers fall back to
+	// the legacy link — a bad base must never fail the underlying operation).
+	public static resolveEmailVerificationLinkBase(linkBase: string | null | undefined): string | null {
+		if (!linkBase || !ValidationHelper.isValidEmailVerificationLinkBase(linkBase)) {
+			return null;
+		}
+		return linkBase.replace(/\/+$/, '');
+	}
+
+	// A confirmation-link prefix a satellite (rocketadmin-saas) may ask the core to embed in the
+	// verification email instead of the legacy `${APP_DOMAIN_ADDRESS}/external/...` link. Only
+	// http(s) URLs without credentials/query/hash pointing at a known SaaS domain are accepted.
+	public static isValidEmailVerificationLinkBase(linkBase: string): boolean {
+		if (typeof linkBase !== 'string' || linkBase.length === 0) {
+			return false;
+		}
+		let parsed: URL;
+		try {
+			parsed = new URL(linkBase);
+		} catch (_e) {
+			return false;
+		}
+		if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+			return false;
+		}
+		if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+			return false;
+		}
+		const allowedHostnames = new Set<string>(Constants.PRIMARY_SAAS_DOMAINS);
+		try {
+			allowedHostnames.add(new URL(Constants.APP_DOMAIN_ADDRESS).hostname);
+		} catch (_e) {
+			// APP_DOMAIN_ADDRESS may be a bare hostname — fall through to the raw value
+			allowedHostnames.add(Constants.APP_DOMAIN_ADDRESS);
+		}
+		if (process.env.NODE_ENV !== 'production') {
+			allowedHostnames.add('localhost');
+			allowedHostnames.add('127.0.0.1');
+		}
+		return allowedHostnames.has(parsed.hostname);
+	}
+
 	public static validateOrThrowHttpExceptionEmail(email: string): boolean {
 		const isEmailValid = ValidationHelper.isValidEmail(email);
 		if (isEmailValid) {

--- a/backend/src/microservices/saas-microservice/data-structures/saas-email-flows.dtos.ts
+++ b/backend/src/microservices/saas-microservice/data-structures/saas-email-flows.dtos.ts
@@ -1,0 +1,56 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { UserRoleEnum } from '../../../entities/user/enums/user-role.enum.js';
+
+// Bodies of the internal (microservice-JWT) email-flow bridges the SaaS control plane calls.
+// The `verificationLinkBase` fields are URL prefixes the token is appended to; they are validated
+// against the SaaS domain allowlist (ValidationHelper.resolveEmailVerificationLinkBase) and fall
+// back to the legacy frontend links when absent or not allowed.
+
+export class SaasUserIdWithLinkBaseDto {
+	@ApiProperty()
+	@IsNotEmpty()
+	@IsString()
+	@IsUUID()
+	userId: string;
+
+	@ApiProperty({ required: false })
+	@IsOptional()
+	@IsString()
+	verificationLinkBase?: string;
+}
+
+export class SaasInviteUserInCompanyDto {
+	@ApiProperty()
+	@IsNotEmpty()
+	@IsString()
+	@IsUUID()
+	inviterId: string;
+
+	@ApiProperty()
+	@IsNotEmpty()
+	@IsString()
+	@IsEmail()
+	email: string;
+
+	@ApiProperty({ enum: UserRoleEnum })
+	@IsNotEmpty()
+	@IsEnum(UserRoleEnum)
+	role: UserRoleEnum;
+
+	@ApiProperty({ required: false })
+	@IsOptional()
+	@IsString()
+	@IsUUID()
+	groupId?: string;
+
+	@ApiProperty({ required: false })
+	@IsOptional()
+	@IsString()
+	inviteLinkBase?: string;
+
+	@ApiProperty({ required: false })
+	@IsOptional()
+	@IsString()
+	emailVerificationLinkBase?: string;
+}

--- a/backend/src/microservices/saas-microservice/saas.controller.ts
+++ b/backend/src/microservices/saas-microservice/saas.controller.ts
@@ -14,14 +14,38 @@ import {
 import { ApiBearerAuth, ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SkipThrottle } from '@nestjs/throttler';
 import { UseCaseType } from '../../common/data-injection.tokens.js';
+import { VerificationString } from '../../decorators/slug-verification.decorator.js';
 import { Timeout } from '../../decorators/timeout.decorator.js';
+import {
+	AcceptedCompanyInvitationDs,
+	AcceptUserValidationInCompany,
+} from '../../entities/company-info/application/data-structures/accept-user-invitation-in-company.ds.js';
 import { FoundUserEmailCompaniesInfoDs } from '../../entities/company-info/application/data-structures/found-company-info.ds.js';
+import { InvitedUserInCompanyAndConnectionGroupDs } from '../../entities/company-info/application/data-structures/invited-user-in-company-and-connection-group.ds.js';
+import { VerifyCompanyInvitationRequestDto } from '../../entities/company-info/application/dto/verify-company-invitation-request-dto.js';
 import { CompanyInfoEntity } from '../../entities/company-info/company-info.entity.js';
+import {
+	IInviteUserInCompanyAndConnectionGroup,
+	IVerifyInviteUserInCompanyAndConnectionGroup,
+} from '../../entities/company-info/use-cases/company-info-use-cases.interface.js';
 import { CreatedConnectionDTO } from '../../entities/connection/application/dto/created-connection.dto.js';
+import { OperationResultMessageDs } from '../../entities/user/application/data-structures/operation-result-message.ds.js';
+import { RegisteredUserDs } from '../../entities/user/application/data-structures/registered-user.ds.js';
 import { SaasUsualUserRegisterDS } from '../../entities/user/application/data-structures/usual-register-user.ds.js';
+import { EmailDto } from '../../entities/user/dto/email.dto.js';
 import { FoundUserDto } from '../../entities/user/dto/found-user.dto.js';
+import { PasswordDto } from '../../entities/user/dto/password.dto.js';
+import { RequestRestUserPasswordDto } from '../../entities/user/dto/request-rest-user-password.dto.js';
 import { ExternalRegistrationProviderEnum } from '../../entities/user/enums/external-registration-provider.enum.js';
-import { ILogOut } from '../../entities/user/use-cases/user-use-cases.interfaces.js';
+import {
+	ILogOut,
+	IRequestEmailChange,
+	IRequestEmailVerification,
+	IRequestPasswordReset,
+	IVerifyEmail,
+	IVerifyEmailChange,
+	IVerifyPasswordReset,
+} from '../../entities/user/use-cases/user-use-cases.interfaces.js';
 import { UserEntity } from '../../entities/user/user.entity.js';
 import { InTransactionEnum } from '../../enums/in-transaction.enum.js';
 import { Messages } from '../../exceptions/text/messages.js';
@@ -40,6 +64,7 @@ import { GetHostedConnectionCredentialsDto } from './data-structures/get-hosted-
 import { HostedConnectionCredentialsRO } from './data-structures/hosted-connection-credentials.ro.js';
 import { RegisterCompanyWebhookDS } from './data-structures/register-company.ds.js';
 import { RegisteredCompanyDS } from './data-structures/registered-company.ds.js';
+import { SaasInviteUserInCompanyDto, SaasUserIdWithLinkBaseDto } from './data-structures/saas-email-flows.dtos.js';
 import { SaasRegisterUserWithGithub } from './data-structures/saas-register-user-with-github.js';
 import { SaasSAMLUserRegisterDS } from './data-structures/saas-saml-user-register.ds.js';
 import { SaasRegisterUserWithGoogleDS } from './data-structures/sass-register-user-with-google.js';
@@ -122,6 +147,22 @@ export class SaasController {
 		private readonly getConnectionsInfoByIdsUseCase: IGetConnectionsInfoByIds,
 		@Inject(UseCaseType.SAAS_GET_HOSTED_CONNECTION_CREDENTIALS)
 		private readonly getHostedConnectionCredentialsUseCase: IGetHostedConnectionCredentials,
+		@Inject(UseCaseType.VERIFY_EMAIL)
+		private readonly verifyEmailUseCase: IVerifyEmail,
+		@Inject(UseCaseType.REQUEST_RESET_USER_PASSWORD)
+		private readonly requestResetUserPasswordUseCase: IRequestPasswordReset,
+		@Inject(UseCaseType.VERIFY_RESET_USER_PASSWORD)
+		private readonly verifyResetUserPasswordUseCase: IVerifyPasswordReset,
+		@Inject(UseCaseType.REQUEST_CHANGE_USER_EMAIL)
+		private readonly requestChangeUserEmailUseCase: IRequestEmailChange,
+		@Inject(UseCaseType.VERIFY_EMAIL_CHANGE)
+		private readonly verifyChangeUserEmailUseCase: IVerifyEmailChange,
+		@Inject(UseCaseType.VERIFY_EMAIL_REQUEST)
+		private readonly requestEmailVerificationUseCase: IRequestEmailVerification,
+		@Inject(UseCaseType.INVITE_USER_IN_COMPANY_AND_CONNECTION_GROUP)
+		private readonly inviteUserInCompanyUseCase: IInviteUserInCompanyAndConnectionGroup,
+		@Inject(UseCaseType.VERIFY_INVITE_USER_IN_COMPANY_AND_CONNECTION_GROUP)
+		private readonly verifyInviteUserInCompanyUseCase: IVerifyInviteUserInCompanyAndConnectionGroup,
 	) {}
 
 	@ApiOperation({ summary: 'Company registered webhook' })
@@ -179,11 +220,144 @@ export class SaasController {
 		@Body('name') name: string,
 		@Body('companyId') companyId: string,
 		@Body('companyName') companyName: string,
+		@Body('emailVerificationLinkBase') emailVerificationLinkBase: string,
 	): Promise<FoundUserDto> {
 		if (!companyId) {
 			throw new BadRequestException(Messages.COMPANY_ID_MISSING);
 		}
-		return await this.usualRegisterUserUseCase.execute({ email, password, gclidValue, name, companyId, companyName });
+		return await this.usualRegisterUserUseCase.execute({
+			email,
+			password,
+			gclidValue,
+			name,
+			companyId,
+			companyName,
+			emailVerificationLinkBase,
+		});
+	}
+
+	// NOTE: declared before `user/email/verify/:verificationString` so the literal `request`
+	// segment is not captured as a verification token.
+	@ApiOperation({ summary: 'Re-send the email-confirmation letter on behalf of the SaaS service' })
+	@ApiBody({ type: SaasUserIdWithLinkBaseDto })
+	@ApiResponse({ status: 201, type: OperationResultMessageDs })
+	@Post('user/email/verify/request')
+	async requestSaasUserEmailVerification(@Body() body: SaasUserIdWithLinkBaseDto): Promise<OperationResultMessageDs> {
+		return await this.requestEmailVerificationUseCase.execute(
+			{ userId: body.userId, verificationLinkBase: body.verificationLinkBase },
+			InTransactionEnum.ON,
+		);
+	}
+
+	@ApiOperation({ summary: 'Verify user email on behalf of the SaaS service' })
+	@ApiResponse({
+		status: 201,
+		description: 'Email verified — the user is activated and the verification token is consumed.',
+		type: OperationResultMessageDs,
+	})
+	@Post('user/email/verify/:verificationString')
+	async verifySaasUserEmail(
+		@VerificationString('verificationString') verificationString: string,
+	): Promise<OperationResultMessageDs> {
+		return await this.verifyEmailUseCase.execute(verificationString, InTransactionEnum.ON);
+	}
+
+	@ApiOperation({ summary: 'Request a password-reset email on behalf of the SaaS service' })
+	@ApiBody({ type: RequestRestUserPasswordDto })
+	@ApiResponse({ status: 201, type: OperationResultMessageDs })
+	@Post('user/password/reset/request')
+	async requestSaasUserPasswordReset(@Body() body: RequestRestUserPasswordDto): Promise<OperationResultMessageDs> {
+		return await this.requestResetUserPasswordUseCase.execute(body, InTransactionEnum.ON);
+	}
+
+	@ApiOperation({ summary: 'Consume a password-reset token on behalf of the SaaS service' })
+	@ApiBody({ type: PasswordDto })
+	@ApiResponse({
+		status: 201,
+		description:
+			'Password replaced; returns the user identity (the core-signed token is ignored by the SaaS caller, ' +
+			'which signs its own cookie).',
+		type: RegisteredUserDs,
+	})
+	@Post('user/password/reset/verify/:verificationString')
+	async verifySaasUserPasswordReset(
+		@VerificationString('verificationString') verificationString: string,
+		@Body() passwordData: PasswordDto,
+	): Promise<RegisteredUserDs> {
+		return await this.verifyResetUserPasswordUseCase.execute(
+			{ verificationString, newUserPassword: passwordData.password },
+			InTransactionEnum.ON,
+		);
+	}
+
+	@ApiOperation({ summary: 'Request an email-change letter on behalf of the SaaS service' })
+	@ApiBody({ type: SaasUserIdWithLinkBaseDto })
+	@ApiResponse({ status: 201, type: OperationResultMessageDs })
+	@Post('user/email/change/request')
+	async requestSaasUserEmailChange(@Body() body: SaasUserIdWithLinkBaseDto): Promise<OperationResultMessageDs> {
+		return await this.requestChangeUserEmailUseCase.execute(
+			{ userId: body.userId, verificationLinkBase: body.verificationLinkBase },
+			InTransactionEnum.ON,
+		);
+	}
+
+	@ApiOperation({ summary: 'Consume an email-change token on behalf of the SaaS service' })
+	@ApiBody({ type: EmailDto })
+	@ApiResponse({ status: 201, type: OperationResultMessageDs })
+	@Post('user/email/change/verify/:verificationString')
+	async verifySaasUserEmailChange(
+		@VerificationString('verificationString') verificationString: string,
+		@Body() emailData: EmailDto,
+	): Promise<OperationResultMessageDs> {
+		return await this.verifyChangeUserEmailUseCase.execute(
+			{ verificationString, newEmail: emailData.email },
+			InTransactionEnum.OFF,
+		);
+	}
+
+	@ApiOperation({ summary: 'Invite a user into a company on behalf of the SaaS service' })
+	@ApiBody({ type: SaasInviteUserInCompanyDto })
+	@ApiResponse({ status: 201, type: InvitedUserInCompanyAndConnectionGroupDs })
+	@Post('company/:companyId/invite')
+	async inviteSaasUserInCompany(
+		@Param('companyId') companyId: string,
+		@Body() body: SaasInviteUserInCompanyDto,
+	): Promise<InvitedUserInCompanyAndConnectionGroupDs> {
+		if (!ValidationHelper.isValidUUID(companyId)) {
+			throw new BadRequestException(Messages.COMPANY_ID_MISSING);
+		}
+		// Authorization (company admin, ownership of inviterId) is enforced by the SaaS caller —
+		// this bridge only trusts the microservice JWT, exactly like `saas/user/register`.
+		return await this.inviteUserInCompanyUseCase.execute({
+			inviterId: body.inviterId,
+			companyId,
+			groupId: body.groupId ?? null,
+			invitedUserEmail: body.email,
+			invitedUserCompanyRole: body.role,
+			inviteLinkBase: body.inviteLinkBase,
+			emailVerificationLinkBase: body.emailVerificationLinkBase,
+		});
+	}
+
+	@ApiOperation({ summary: 'Accept a company invitation on behalf of the SaaS service' })
+	@ApiBody({ type: VerifyCompanyInvitationRequestDto })
+	@ApiResponse({
+		status: 201,
+		description: 'Invitation accepted; returns the user identity so the SaaS caller can sign its own cookie.',
+		type: AcceptedCompanyInvitationDs,
+	})
+	@Post('company/invite/verify/:verificationString')
+	async verifySaasCompanyInvitation(
+		@VerificationString('verificationString') verificationString: string,
+		@Body() verificationData: VerifyCompanyInvitationRequestDto,
+	): Promise<AcceptedCompanyInvitationDs> {
+		ValidationHelper.isPasswordStrongOrThrowError(verificationData.password);
+		const inputData: AcceptUserValidationInCompany = {
+			verificationString,
+			userPassword: verificationData.password,
+			userName: verificationData.userName,
+		};
+		return await this.verifyInviteUserInCompanyUseCase.execute(inputData, InTransactionEnum.OFF);
 	}
 
 	@ApiOperation({ summary: 'Validate an end-user JWT on behalf of the SaaS service' })

--- a/backend/src/microservices/saas-microservice/saas.module.ts
+++ b/backend/src/microservices/saas-microservice/saas.module.ts
@@ -3,7 +3,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { SaaSAuthMiddleware } from '../../authorization/saas-auth.middleware.js';
 import { GlobalDatabaseContext } from '../../common/application/global-database-context.js';
 import { BaseType, UseCaseType } from '../../common/data-injection.tokens.js';
+import { CompanyInfoHelperService } from '../../entities/company-info/company-info-helper.service.js';
+import { InviteUserInCompanyAndConnectionGroupUseCase } from '../../entities/company-info/use-cases/invite-user-in-company.use.case.js';
+import { VerifyInviteUserInCompanyAndConnectionGroupUseCase } from '../../entities/company-info/use-cases/verify-invite-user-in-company.use.case.js';
 import { LogOutUseCase } from '../../entities/user/use-cases/log-out.use.case.js';
+import { RequestChangeUserEmailUseCase } from '../../entities/user/use-cases/request-change-user-email.use.case.js';
+import { RequestEmailVerificationUseCase } from '../../entities/user/use-cases/request-email-verification.use.case.js';
+import { RequestResetUserPasswordUseCase } from '../../entities/user/use-cases/request-reset-user-password.use.case.js';
+import { VerifyChangeUserEmailUseCase } from '../../entities/user/use-cases/verify-change-user-email.use.case.js';
+import { VerifyResetUserPasswordUseCase } from '../../entities/user/use-cases/verify-reset-user-password.use.case.js';
+import { VerifyUserEmailUseCase } from '../../entities/user/use-cases/verify-user-email.use.case.js';
 import { UserEntity } from '../../entities/user/user.entity.js';
 import { SignInAuditEntity } from '../../entities/user-sign-in-audit/sign-in-audit.entity.js';
 import { SignInAuditService } from '../../entities/user-sign-in-audit/sign-in-audit.service.js';
@@ -130,6 +139,39 @@ import { UpdateHostedConnectionPasswordUseCase } from './use-cases/update-hosted
 			provide: UseCaseType.SAAS_GET_HOSTED_CONNECTION_CREDENTIALS,
 			useClass: GetHostedConnectionCredentialsUseCase,
 		},
+		{
+			provide: UseCaseType.VERIFY_EMAIL,
+			useClass: VerifyUserEmailUseCase,
+		},
+		{
+			provide: UseCaseType.REQUEST_RESET_USER_PASSWORD,
+			useClass: RequestResetUserPasswordUseCase,
+		},
+		{
+			provide: UseCaseType.VERIFY_RESET_USER_PASSWORD,
+			useClass: VerifyResetUserPasswordUseCase,
+		},
+		{
+			provide: UseCaseType.REQUEST_CHANGE_USER_EMAIL,
+			useClass: RequestChangeUserEmailUseCase,
+		},
+		{
+			provide: UseCaseType.VERIFY_EMAIL_CHANGE,
+			useClass: VerifyChangeUserEmailUseCase,
+		},
+		{
+			provide: UseCaseType.VERIFY_EMAIL_REQUEST,
+			useClass: RequestEmailVerificationUseCase,
+		},
+		{
+			provide: UseCaseType.INVITE_USER_IN_COMPANY_AND_CONNECTION_GROUP,
+			useClass: InviteUserInCompanyAndConnectionGroupUseCase,
+		},
+		{
+			provide: UseCaseType.VERIFY_INVITE_USER_IN_COMPANY_AND_CONNECTION_GROUP,
+			useClass: VerifyInviteUserInCompanyAndConnectionGroupUseCase,
+		},
+		CompanyInfoHelperService,
 		SignInAuditService,
 	],
 	controllers: [SaasController],
@@ -144,6 +186,14 @@ export class SaasModule {
 				{ path: 'saas/user/:userId', method: RequestMethod.GET },
 				{ path: 'saas/users/email/:userEmail', method: RequestMethod.GET },
 				{ path: 'saas/user/register', method: RequestMethod.POST },
+				{ path: 'saas/user/email/verify/request', method: RequestMethod.POST },
+				{ path: 'saas/user/email/verify/:verificationString', method: RequestMethod.POST },
+				{ path: 'saas/user/password/reset/request', method: RequestMethod.POST },
+				{ path: 'saas/user/password/reset/verify/:verificationString', method: RequestMethod.POST },
+				{ path: 'saas/user/email/change/request', method: RequestMethod.POST },
+				{ path: 'saas/user/email/change/verify/:verificationString', method: RequestMethod.POST },
+				{ path: 'saas/company/:companyId/invite', method: RequestMethod.POST },
+				{ path: 'saas/company/invite/verify/:verificationString', method: RequestMethod.POST },
 				{ path: 'saas/user/login', method: RequestMethod.POST },
 				{ path: 'saas/user/logout', method: RequestMethod.POST },
 				{ path: 'saas/user/validate-token', method: RequestMethod.POST },

--- a/backend/src/microservices/saas-microservice/use-cases/saas-usual-register-user.use.case.ts
+++ b/backend/src/microservices/saas-microservice/use-cases/saas-usual-register-user.use.case.ts
@@ -12,6 +12,7 @@ import { FoundUserDto } from '../../../entities/user/dto/found-user.dto.js';
 import { UserRoleEnum } from '../../../entities/user/enums/user-role.enum.js';
 import { UserEntity } from '../../../entities/user/user.entity.js';
 import { Messages } from '../../../exceptions/text/messages.js';
+import { ValidationHelper } from '../../../helpers/validators/validation-helper.js';
 import { SaasCompanyGatewayService } from '../../gateways/saas-gateway.ts/saas-company-gateway.service.js';
 import { ISaasRegisterUser } from './saas-use-cases.interface.js';
 
@@ -31,7 +32,7 @@ export class SaasUsualRegisterUseCase
 	}
 
 	protected async implementation(userData: SaasUsualUserRegisterDS): Promise<FoundUserDto> {
-		const { email, password, gclidValue, name, companyId, companyName } = userData;
+		const { email, password, gclidValue, name, companyId, companyName, emailVerificationLinkBase } = userData;
 		const foundUser = await this._dbContext.userRepository.findOneUserByEmailAndCompanyId(email, companyId);
 		const userCompany = await this._dbContext.companyInfoRepository.findCompanyInfoWithUsersById(companyId);
 
@@ -66,7 +67,11 @@ export class SaasUsualRegisterUseCase
 		const { rawToken } = await this._dbContext.emailVerificationRepository.createOrUpdateEmailVerification(savedUser);
 		const companyCustomDomain = await this.saasCompanyGatewayService.getCompanyCustomDomainById(companyId);
 
-		await this.emailService.sendEmailConfirmation(savedUser.email, rawToken, companyCustomDomain);
+		// The satellite may route the confirmation link through itself (SiteNova). A disallowed or
+		// malformed base silently falls back to the legacy link — never fail the registration over it.
+		const verificationLinkBase = ValidationHelper.resolveEmailVerificationLinkBase(emailVerificationLinkBase);
+
+		await this.emailService.sendEmailConfirmation(savedUser.email, rawToken, companyCustomDomain, verificationLinkBase);
 
 		return {
 			id: savedUser.id,

--- a/backend/test/ava-tests/saas-tests/saas-user-email-flows-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/saas-user-email-flows-e2e.test.ts
@@ -1,0 +1,343 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import test from 'ava';
+import { ValidationError } from 'class-validator';
+import cookieParser from 'cookie-parser';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { ApplicationModule } from '../../../src/app.module.js';
+import { BaseType } from '../../../src/common/data-injection.tokens.js';
+import { WinstonLogger } from '../../../src/entities/logging/winston-logger.js';
+import { UserEntity } from '../../../src/entities/user/user.entity.js';
+import { EmailChangeEntity } from '../../../src/entities/user/user-email/email-change.entity.js';
+import { emailChangeCustomRepositoryExtension } from '../../../src/entities/user/user-email/repository/email-change-custom-repository-extension.js';
+import { PasswordResetEntity } from '../../../src/entities/user/user-password/password-reset.entity.js';
+import { userPasswordResetCustomRepositoryExtension } from '../../../src/entities/user/user-password/repository/user-password-custom-repository-extension.js';
+import { AllExceptionsFilter } from '../../../src/exceptions/all-exceptions.filter.js';
+import { ValidationException } from '../../../src/exceptions/custom-exceptions/validation-exception.js';
+import { Cacher } from '../../../src/helpers/cache/cacher.js';
+import { appConfig } from '../../../src/shared/config/app-config.js';
+import { DatabaseModule } from '../../../src/shared/database/database.module.js';
+import { DatabaseService } from '../../../src/shared/database/database.service.js';
+import { TestUtils } from '../../utils/test.utils.js';
+
+// Tests for the plan-11 internal email-flow bridges rocketadmin-saas calls (microservice JWT):
+//   POST /saas/user/password/reset/request | /saas/user/password/reset/verify/:token
+//   POST /saas/user/email/change/request   | /saas/user/email/change/verify/:token
+//   POST /saas/user/email/verify/request   (re-send confirmation)
+//   POST /saas/company/:companyId/invite   | /saas/company/invite/verify/:token
+// The invite happy-path verification is covered in rocketadmin-saas's own suite (it needs the
+// company row in the SaaS DB for the recount webhook); here we cover everything reachable with
+// the core alone. Raw tokens are minted through the same repository extensions production uses.
+
+let app: INestApplication;
+let currentTest: string;
+let _testUtils: TestUtils;
+
+const STRONG_PASSWORD = `#r@dY^e&7R4b5Ib@31iE4xbn`;
+
+function microserviceAuthHeader(): string {
+	const token = jwt.sign({ request_id: faker.string.uuid() }, appConfig.auth.microserviceJwtSecret);
+	return `Bearer ${token}`;
+}
+
+async function registerUser(): Promise<{ userId: string; email: string; companyId: string }> {
+	const body = {
+		email: `${faker.lorem.word()}_${faker.string.alphanumeric(6)}_${faker.internet.email()}`.toLowerCase(),
+		password: STRONG_PASSWORD,
+		name: faker.person.firstName(),
+		companyId: faker.string.uuid(),
+		companyName: faker.company.name(),
+		gclidValue: null,
+	};
+	const result = await request(app.getHttpServer())
+		.post('/saas/user/register')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json')
+		.send(body);
+	if (result.status !== 201) {
+		throw new Error(`Test user registration failed: ${result.status} ${result.text}`);
+	}
+	const ro = JSON.parse(result.text);
+	return { userId: ro.id, email: ro.email, companyId: body.companyId };
+}
+
+async function findUser(userId: string): Promise<UserEntity | null> {
+	const dataSource = app.get<DataSource>(BaseType.DATA_SOURCE);
+	return await dataSource.getRepository(UserEntity).findOne({ where: { id: userId } });
+}
+
+async function activateUser(userId: string): Promise<void> {
+	const dataSource = app.get<DataSource>(BaseType.DATA_SOURCE);
+	const userRepository = dataSource.getRepository(UserEntity);
+	const user = await userRepository.findOne({ where: { id: userId } });
+	user.isActive = true;
+	await userRepository.save(user);
+}
+
+async function mintPasswordResetToken(userId: string): Promise<string> {
+	const dataSource = app.get<DataSource>(BaseType.DATA_SOURCE);
+	const repo = dataSource.getRepository(PasswordResetEntity).extend(userPasswordResetCustomRepositoryExtension);
+	const user = await dataSource.getRepository(UserEntity).findOne({ where: { id: userId } });
+	const { rawToken } = await repo.createOrUpdatePasswordResetEntity(user);
+	return rawToken;
+}
+
+async function mintEmailChangeToken(userId: string): Promise<string> {
+	const dataSource = app.get<DataSource>(BaseType.DATA_SOURCE);
+	const repo = dataSource.getRepository(EmailChangeEntity).extend(emailChangeCustomRepositoryExtension);
+	const user = await dataSource.getRepository(UserEntity).findOne({ where: { id: userId } });
+	const { rawToken } = await repo.createOrUpdateEmailChangeEntity(user);
+	return rawToken;
+}
+
+test.before(async () => {
+	const moduleFixture = await Test.createTestingModule({
+		imports: [ApplicationModule, DatabaseModule],
+		providers: [DatabaseService, TestUtils],
+	}).compile();
+	app = moduleFixture.createNestApplication();
+	_testUtils = moduleFixture.get<TestUtils>(TestUtils);
+
+	app.use(cookieParser());
+	app.useGlobalFilters(new AllExceptionsFilter(app.get(WinstonLogger)));
+	app.useGlobalPipes(
+		new ValidationPipe({
+			exceptionFactory(validationErrors: ValidationError[] = []) {
+				return new ValidationException(validationErrors);
+			},
+		}),
+	);
+	await app.init();
+	app.getHttpServer().listen(0);
+});
+
+test.after(async () => {
+	try {
+		await Cacher.clearAllCache();
+		await app.close();
+	} catch (e) {
+		console.error('After tests error ' + e);
+	}
+});
+
+currentTest = 'POST /saas/user/password/reset/request';
+
+test.serial(`${currentTest} accepts a known user (with a link base) and requests the reset`, async (t) => {
+	const { email, companyId } = await registerUser();
+
+	const result = await request(app.getHttpServer())
+		.post('/saas/user/password/reset/request')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ email, companyId, verificationLinkBase: 'https://app.sitenova.com/password-reset' });
+
+	t.is(result.status, 201);
+	t.pass();
+});
+
+test.serial(`${currentTest} rejects an unknown user`, async (t) => {
+	const result = await request(app.getHttpServer())
+		.post('/saas/user/password/reset/request')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ email: `nobody_${faker.string.alphanumeric(8)}@example.com`, companyId: faker.string.uuid() });
+
+	t.is(result.status, 403);
+	t.pass();
+});
+
+currentTest = 'POST /saas/user/password/reset/verify/:verificationString';
+
+test.serial(`${currentTest} replaces the password (login bridge accepts the new one)`, async (t) => {
+	const { userId, email, companyId } = await registerUser();
+	const rawToken = await mintPasswordResetToken(userId);
+	const newPassword = `N3w!${STRONG_PASSWORD}`;
+
+	const result = await request(app.getHttpServer())
+		.post(`/saas/user/password/reset/verify/${rawToken}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ password: newPassword });
+
+	t.is(result.status, 201);
+	const ro = JSON.parse(result.text);
+	t.is(ro.id, userId);
+	t.is(ro.email, email);
+
+	const loginResult = await request(app.getHttpServer())
+		.post('/saas/user/login')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ email, password: newPassword, companyId, request_domain: '127.0.0.1' });
+	t.is(loginResult.status, 201);
+
+	const oldPasswordLogin = await request(app.getHttpServer())
+		.post('/saas/user/login')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ email, password: STRONG_PASSWORD, companyId, request_domain: '127.0.0.1' });
+	t.is(oldPasswordLogin.status, 400);
+	t.pass();
+});
+
+test.serial(`${currentTest} rejects an unknown token`, async (t) => {
+	const result = await request(app.getHttpServer())
+		.post(`/saas/user/password/reset/verify/${'b'.repeat(40)}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ password: STRONG_PASSWORD });
+
+	t.is(result.status, 400);
+	t.pass();
+});
+
+currentTest = 'POST /saas/user/email/change/request';
+
+test.serial(`${currentTest} rejects an inactive user and accepts an activated one`, async (t) => {
+	const { userId } = await registerUser();
+
+	const inactiveResult = await request(app.getHttpServer())
+		.post('/saas/user/email/change/request')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ userId });
+	t.is(inactiveResult.status, 403);
+
+	await activateUser(userId);
+
+	const activeResult = await request(app.getHttpServer())
+		.post('/saas/user/email/change/request')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ userId, verificationLinkBase: 'https://app.sitenova.com/email-change' });
+	t.is(activeResult.status, 201);
+	t.pass();
+});
+
+currentTest = 'POST /saas/user/email/change/verify/:verificationString';
+
+test.serial(`${currentTest} changes the email and consumes the token`, async (t) => {
+	const { userId } = await registerUser();
+	await activateUser(userId);
+	const rawToken = await mintEmailChangeToken(userId);
+	const newEmail = `changed_${faker.string.alphanumeric(8)}@example.com`.toLowerCase();
+
+	const result = await request(app.getHttpServer())
+		.post(`/saas/user/email/change/verify/${rawToken}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ email: newEmail });
+
+	t.is(result.status, 201);
+	const user = await findUser(userId);
+	t.is(user.email, newEmail);
+
+	// the token is single-use
+	const secondResult = await request(app.getHttpServer())
+		.post(`/saas/user/email/change/verify/${rawToken}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ email: `other_${newEmail}` });
+	t.is(secondResult.status, 400);
+	t.pass();
+});
+
+test.serial(`${currentTest} rejects an email that is already in use`, async (t) => {
+	const { userId } = await registerUser();
+	const { email: takenEmail } = await registerUser();
+	await activateUser(userId);
+	const rawToken = await mintEmailChangeToken(userId);
+
+	const result = await request(app.getHttpServer())
+		.post(`/saas/user/email/change/verify/${rawToken}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ email: takenEmail });
+
+	t.is(result.status, 400);
+	t.pass();
+});
+
+currentTest = 'POST /saas/user/email/verify/request';
+
+test.serial(`${currentTest} re-sends for an inactive user and rejects an already-confirmed one`, async (t) => {
+	const { userId } = await registerUser();
+
+	const result = await request(app.getHttpServer())
+		.post('/saas/user/email/verify/request')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ userId, verificationLinkBase: 'https://app.sitenova.com/saas/user/email/verify' });
+	t.is(result.status, 201);
+
+	await activateUser(userId);
+
+	const confirmedResult = await request(app.getHttpServer())
+		.post('/saas/user/email/verify/request')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ userId });
+	t.is(confirmedResult.status, 400);
+	t.pass();
+});
+
+currentTest = 'POST /saas/company/:companyId/invite';
+
+test.serial(`${currentTest} creates an invitation (token surfaced only under test env)`, async (t) => {
+	const { userId, companyId } = await registerUser();
+	const invitedEmail = `invited_${faker.string.alphanumeric(8)}@example.com`.toLowerCase();
+
+	const result = await request(app.getHttpServer())
+		.post(`/saas/company/${companyId}/invite`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({
+			inviterId: userId,
+			email: invitedEmail,
+			role: 'USER',
+			inviteLinkBase: `https://app.sitenova.com/invite/${companyId}`,
+		});
+
+	t.is(result.status, 201);
+	const ro = JSON.parse(result.text);
+	t.is(ro.email, invitedEmail);
+	t.is(ro.companyId, companyId);
+	t.is(typeof ro.verificationString, 'string');
+	t.pass();
+});
+
+currentTest = 'POST /saas/company/invite/verify/:verificationString';
+
+test.serial(`${currentTest} rejects an unknown token`, async (t) => {
+	const result = await request(app.getHttpServer())
+		.post(`/saas/company/invite/verify/${'c'.repeat(40)}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.send({ password: STRONG_PASSWORD, userName: 'Invited User' });
+
+	t.is(result.status, 400);
+	t.pass();
+});
+
+currentTest = 'internal email-flow endpoints auth';
+
+test.serial(`${currentTest} reject requests without a microservice JWT`, async (t) => {
+	const paths = [
+		'/saas/user/password/reset/request',
+		`/saas/user/password/reset/verify/${'d'.repeat(40)}`,
+		'/saas/user/email/change/request',
+		`/saas/user/email/change/verify/${'d'.repeat(40)}`,
+		'/saas/user/email/verify/request',
+		`/saas/company/${faker.string.uuid()}/invite`,
+		`/saas/company/invite/verify/${'d'.repeat(40)}`,
+	];
+	for (const path of paths) {
+		const result = await request(app.getHttpServer()).post(path).set('Content-Type', 'application/json').send({});
+		t.is(result.status, 401, `expected 401 for ${path}`);
+	}
+	t.pass();
+});

--- a/backend/test/ava-tests/saas-tests/saas-user-email-verification-e2e.test.ts
+++ b/backend/test/ava-tests/saas-tests/saas-user-email-verification-e2e.test.ts
@@ -1,0 +1,217 @@
+import { faker } from '@faker-js/faker';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import test from 'ava';
+import { ValidationError } from 'class-validator';
+import cookieParser from 'cookie-parser';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import { DataSource } from 'typeorm';
+import { ApplicationModule } from '../../../src/app.module.js';
+import { BaseType } from '../../../src/common/data-injection.tokens.js';
+import { EmailVerificationEntity } from '../../../src/entities/email/email-verification.entity.js';
+import { emailVerificationRepositoryExtension } from '../../../src/entities/email/repository/email-verification-custom-repository-extension.js';
+import { WinstonLogger } from '../../../src/entities/logging/winston-logger.js';
+import { UserEntity } from '../../../src/entities/user/user.entity.js';
+import { AllExceptionsFilter } from '../../../src/exceptions/all-exceptions.filter.js';
+import { ValidationException } from '../../../src/exceptions/custom-exceptions/validation-exception.js';
+import { Cacher } from '../../../src/helpers/cache/cacher.js';
+import { appConfig } from '../../../src/shared/config/app-config.js';
+import { DatabaseModule } from '../../../src/shared/database/database.module.js';
+import { DatabaseService } from '../../../src/shared/database/database.service.js';
+import { TestUtils } from '../../utils/test.utils.js';
+
+// Tests for the SaaS email-verification bridge POST /saas/user/email/verify/:verificationString
+// (SaaSAuthMiddleware / microservice JWT) and the optional `emailVerificationLinkBase` field of
+// POST /saas/user/register. rocketadmin-saas routes SiteNova confirmation links through itself
+// (GET /saas/user/email/verify/:token) and consumes them via this internal endpoint — the public
+// browser route GET /user/email/verify/:slug is unaffected.
+
+let app: INestApplication;
+let currentTest: string;
+let _testUtils: TestUtils;
+
+// A microservice JWT identical in shape to the one rocketadmin-saas signs (payload { request_id }).
+function microserviceAuthHeader(): string {
+	const token = jwt.sign({ request_id: faker.string.uuid() }, appConfig.auth.microserviceJwtSecret);
+	return `Bearer ${token}`;
+}
+
+function buildRegistrationBody(extraFields: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		email: `${faker.lorem.word()}_${faker.string.alphanumeric(6)}_${faker.internet.email()}`.toLowerCase(),
+		password: `#r@dY^e&7R4b5Ib@31iE4xbn`,
+		name: faker.person.firstName(),
+		companyId: faker.string.uuid(),
+		companyName: faker.company.name(),
+		gclidValue: null,
+		...extraFields,
+	};
+}
+
+async function registerUser(extraFields: Record<string, unknown> = {}): Promise<{ userId: string; email: string }> {
+	const body = buildRegistrationBody(extraFields);
+	const result = await request(app.getHttpServer())
+		.post('/saas/user/register')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json')
+		.send(body);
+	if (result.status !== 201) {
+		throw new Error(`Test user registration failed: ${result.status} ${result.text}`);
+	}
+	const ro = JSON.parse(result.text);
+	return { userId: ro.id, email: ro.email };
+}
+
+// The raw token is (correctly) never returned by the register endpoint — replace the verification
+// row through the same repository extension the production code uses and keep the fresh raw token.
+async function mintVerificationToken(userId: string): Promise<string> {
+	const dataSource = app.get<DataSource>(BaseType.DATA_SOURCE);
+	const userRepository = dataSource.getRepository(UserEntity);
+	const emailVerificationRepository = dataSource
+		.getRepository(EmailVerificationEntity)
+		.extend(emailVerificationRepositoryExtension);
+	const user = await userRepository.findOne({
+		where: { id: userId },
+		relations: { email_verification: true },
+	});
+	const { rawToken } = await emailVerificationRepository.createOrUpdateEmailVerification(user);
+	return rawToken;
+}
+
+async function findUser(userId: string): Promise<UserEntity | null> {
+	const dataSource = app.get<DataSource>(BaseType.DATA_SOURCE);
+	return await dataSource.getRepository(UserEntity).findOne({
+		where: { id: userId },
+		relations: { email_verification: true },
+	});
+}
+
+test.before(async () => {
+	const moduleFixture = await Test.createTestingModule({
+		imports: [ApplicationModule, DatabaseModule],
+		providers: [DatabaseService, TestUtils],
+	}).compile();
+	app = moduleFixture.createNestApplication();
+	_testUtils = moduleFixture.get<TestUtils>(TestUtils);
+
+	app.use(cookieParser());
+	app.useGlobalFilters(new AllExceptionsFilter(app.get(WinstonLogger)));
+	app.useGlobalPipes(
+		new ValidationPipe({
+			exceptionFactory(validationErrors: ValidationError[] = []) {
+				return new ValidationException(validationErrors);
+			},
+		}),
+	);
+	await app.init();
+	app.getHttpServer().listen(0);
+});
+
+test.after(async () => {
+	try {
+		await Cacher.clearAllCache();
+		await app.close();
+	} catch (e) {
+		console.error('After tests error ' + e);
+	}
+});
+
+currentTest = 'POST /saas/user/register (emailVerificationLinkBase)';
+
+test.serial(`${currentTest} accepts an allowed link base and registers the user inactive`, async (t) => {
+	const result = await request(app.getHttpServer())
+		.post('/saas/user/register')
+		.set('Authorization', microserviceAuthHeader())
+		.set('Content-Type', 'application/json')
+		.set('Accept', 'application/json')
+		.send(buildRegistrationBody({ emailVerificationLinkBase: 'https://app.sitenova.com/saas/user/email/verify' }));
+
+	t.is(result.status, 201);
+	const ro = JSON.parse(result.text);
+	t.is(ro.isActive, false);
+	t.pass();
+});
+
+test.serial(`${currentTest} tolerates malformed and disallowed link bases (falls back to legacy link)`, async (t) => {
+	for (const emailVerificationLinkBase of [
+		'not a url at all',
+		'ftp://app.sitenova.com/saas/user/email/verify',
+		'https://evil.example.com/steal',
+		'https://app.sitenova.com/x?query=1',
+	]) {
+		const result = await request(app.getHttpServer())
+			.post('/saas/user/register')
+			.set('Authorization', microserviceAuthHeader())
+			.set('Content-Type', 'application/json')
+			.set('Accept', 'application/json')
+			.send(buildRegistrationBody({ emailVerificationLinkBase }));
+
+		t.is(result.status, 201, `registration must not fail for link base "${emailVerificationLinkBase}"`);
+	}
+	t.pass();
+});
+
+currentTest = 'POST /saas/user/email/verify/:verificationString';
+
+test.serial(`${currentTest} activates the user and consumes the token`, async (t) => {
+	const { userId } = await registerUser();
+	const rawToken = await mintVerificationToken(userId);
+
+	const result = await request(app.getHttpServer())
+		.post(`/saas/user/email/verify/${rawToken}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Accept', 'application/json');
+
+	t.is(result.status, 201);
+
+	const user = await findUser(userId);
+	t.is(user.isActive, true);
+	t.is(user.email_verification, null);
+
+	// the token is single-use
+	const secondResult = await request(app.getHttpServer())
+		.post(`/saas/user/email/verify/${rawToken}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Accept', 'application/json');
+	t.is(secondResult.status, 400);
+	t.pass();
+});
+
+test.serial(`${currentTest} rejects an unknown token`, async (t) => {
+	const { userId } = await registerUser();
+	await mintVerificationToken(userId);
+
+	const result = await request(app.getHttpServer())
+		.post(`/saas/user/email/verify/${'a'.repeat(40)}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Accept', 'application/json');
+
+	t.is(result.status, 400);
+	const user = await findUser(userId);
+	t.is(user.isActive, false);
+	t.pass();
+});
+
+test.serial(`${currentTest} rejects a malformed token`, async (t) => {
+	const result = await request(app.getHttpServer())
+		.post(`/saas/user/email/verify/${encodeURIComponent('not$a%valid*token!')}`)
+		.set('Authorization', microserviceAuthHeader())
+		.set('Accept', 'application/json');
+
+	t.is(result.status, 400);
+	t.pass();
+});
+
+test.serial(`${currentTest} rejects a request without a microservice JWT`, async (t) => {
+	const { userId } = await registerUser();
+	const rawToken = await mintVerificationToken(userId);
+
+	const result = await request(app.getHttpServer()).post(`/saas/user/email/verify/${rawToken}`);
+
+	t.is(result.status, 401);
+	const user = await findUser(userId);
+	t.is(user.isActive, false);
+	t.pass();
+});


### PR DESCRIPTION
- Implemented `resolveEmailVerificationLinkBase` and `isValidEmailVerificationLinkBase` methods in `ValidationHelper` to normalize and validate email verification link bases.
- Created DTOs `SaasUserIdWithLinkBaseDto` and `SaasInviteUserInCompanyDto` for handling user and invitation data with optional link bases.
- Enhanced `SaasController` to handle email verification requests, including re-sending verification emails and verifying user emails.
- Updated `SaasUsualRegisterUseCase` to include email verification link base handling during user registration.
- Added comprehensive end-to-end tests for email verification and user invitation flows, ensuring proper handling of link bases and token verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SaaS endpoints for email verification, password resets, email changes, company invitations, and invitation acceptance.
  * Invitation acceptance now returns authenticated user and company details.
  * Email flows support configurable verification and invitation link prefixes.
  * Added validation for custom link prefixes, with safe fallback to standard links.
  * Added request validation and authorization across the new endpoints.

* **Bug Fixes**
  * Improved handling of invalid or unsupported custom links without interrupting registration or email delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->