### PR TITLE
feat: add SITENOVA_PAID_PLAN to subscription levels with detailed comments

### DIFF
--- a/backend/src/enums/subscription-level.enum.ts
+++ b/backend/src/enums/subscription-level.enum.ts
@@ -4,4 +4,7 @@ export enum SubscriptionLevelEnum {
 	ENTERPRISE_PLAN = 'ENTERPRISE_PLAN',
 	ANNUAL_TEAM_PLAN = 'ANNUAL_TEAM_PLAN',
 	ANNUAL_ENTERPRISE_PLAN = 'ANNUAL_ENTERPRISE_PLAN',
+	// SiteNova paid plan (saas plan 38): flat price + metered token overage. Reported by saas like the
+	// others; every `=== FREE_PLAN` check here treats it as paid.
+	SITENOVA_PAID_PLAN = 'SITENOVA_PAID_PLAN',
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the SiteNova paid subscription plan, including flat-rate pricing with metered token overage.
  - The new plan is reported consistently with other paid subscription plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->